### PR TITLE
[BIA-452] Fixed DescriptorMap insert for Instructional day (pgsql).

### DIFF
--- a/src/EdFi.AnalyticsMiddleTier.DataStandard32/Ews/PostgreSQL/0004-Data-DefaultDescriptorMap.sql
+++ b/src/EdFi.AnalyticsMiddleTier.DataStandard32/Ews/PostgreSQL/0004-Data-DefaultDescriptorMap.sql
@@ -90,7 +90,7 @@ WITH present as (
 			edfi.CalendarEventDescriptor ON
 				Descriptor.DescriptorId = CalendarEventDescriptor.CalendarEventDescriptorId
 		WHERE
-			Descriptor.CodeValue IN ('Instructional Day', 'Instructional day', 'Make-up day', 'Make-up day')
+			Descriptor.CodeValue IN ('Instructional Day', 'Instructional day', 'Make-up Day', 'Make-up day')
 	) as d
 	WHERE DescriptorConstant.ConstantName = 'CalendarEvent.InstructionalDay'
 ), stateOffenses as (

--- a/src/EdFi.AnalyticsMiddleTier.DataStandard32/Ews/PostgreSQL/0004-Data-DefaultDescriptorMap.sql
+++ b/src/EdFi.AnalyticsMiddleTier.DataStandard32/Ews/PostgreSQL/0004-Data-DefaultDescriptorMap.sql
@@ -90,7 +90,7 @@ WITH present as (
 			edfi.CalendarEventDescriptor ON
 				Descriptor.DescriptorId = CalendarEventDescriptor.CalendarEventDescriptorId
 		WHERE
-			Descriptor.CodeValue IN ('Instructional Day', 'Make-up day')
+			Descriptor.CodeValue IN ('Instructional Day', 'Instructional day', 'Make-up day', 'Make-up day')
 	) as d
 	WHERE DescriptorConstant.ConstantName = 'CalendarEvent.InstructionalDay'
 ), stateOffenses as (


### PR DESCRIPTION
Postgresql is case sensitive, we need to use 'Instructional day' instead of 'Instructional Day' in the filter.