### PR TITLE
[BIA-480] Adds assessment collection to the installer.

### DIFF
--- a/src/EdFi.AnalyticsMiddleTier.Common/Component.cs
+++ b/src/EdFi.AnalyticsMiddleTier.Common/Component.cs
@@ -19,7 +19,8 @@ namespace EdFi.AnalyticsMiddleTier.Common
         Qews,
         Ews,
         RLS,
-        Chrab
+        Chrab,
+        Asmt
     }
     public enum DataStandard
     {

--- a/src/EdFi.AnalyticsMiddleTier.Console/Program.cs
+++ b/src/EdFi.AnalyticsMiddleTier.Console/Program.cs
@@ -34,6 +34,9 @@ namespace EdFi.AnalyticsMiddleTier.Console
                                                                                                                                                          System.Environment.NewLine
                                                                                                                                                          + "* Data Standard 3.2 (auto-detect presence of DeployJournal table)" +
                                                                                                                                                          System.Environment.NewLine;
+        private static readonly string _asmtNotSupportedOnDS2
+            = "Assessment collection is not currently supported on Data Standard 2. Please remove this option and try again.";
+
         internal static void Main(string[] args)
         {
             var parser = new Parser(settings =>
@@ -141,6 +144,9 @@ namespace EdFi.AnalyticsMiddleTier.Console
                                     break;
                             }
                         }
+
+                        if (dataStandardVersion == DataStandard.Ds2 && options.Components.Contains(Component.Asmt))
+                            message = _asmtNotSupportedOnDS2;
 
                         if (String.IsNullOrEmpty(message))
                         {


### PR DESCRIPTION
### Testing
To test this we need to include the **Asmt** option to the installer command and execute it. The installer should not throw any errors. Since at this point we don't have any new views, no view will be installed.

Additionally, try to install AMT on DS2. The installer should throw an error to indicate that the assessment collection is not supported on this DS.