### PR TITLE
[BIA-491] Remove postgres warnings from console

### DIFF
--- a/src/EdFi.AnalyticsMiddleTier.Console/Program.cs
+++ b/src/EdFi.AnalyticsMiddleTier.Console/Program.cs
@@ -20,10 +20,6 @@ namespace EdFi.AnalyticsMiddleTier.Console
 {
     internal class Program
     {
-        private static readonly string _postgresqlWarning
-            = "> .\\EdFi.AnalytcsMiddleTier.Console.exe --connectionString \"...\" --engine postgres " + System.Environment.NewLine + System.Environment.NewLine
-              + "Warning: PostgreSQL is an experimental feature that has not been fully tested " + System.Environment.NewLine
-              + "yet. To proceed with the install, rerun the command using switch --experimental.";
 
         private static readonly string _odsVersionNotSupportedMessage
             = "Unable to determine the ODS database version. Please submit a ticket in Tracker for assistance: https://tracker.ed-fi.org/projects/EDFI." + System.Environment.NewLine + System.Environment.NewLine
@@ -112,15 +108,8 @@ namespace EdFi.AnalyticsMiddleTier.Console
                             case Engine.Postgres:
                             case Engine.Postgresql:
                             case Engine.PostgreSQL:
-                                if (options.Experimental)
-                                {
-                                    var pgsqlOrm = new DapperWrapper(new NpgsqlConnection(options.ConnectionString));
-                                    migrationStrategy = new PostgresMigrationStrategy(pgsqlOrm);
-                                }
-                                else
-                                {
-                                    message = _postgresqlWarning;
-                                }
+                                var pgsqlOrm = new DapperWrapper(new NpgsqlConnection(options.ConnectionString));
+                                migrationStrategy = new PostgresMigrationStrategy(pgsqlOrm);
                                 break;
                         }
 

--- a/src/EdFi.AnalyticsMiddleTier.Console/Program.cs
+++ b/src/EdFi.AnalyticsMiddleTier.Console/Program.cs
@@ -121,7 +121,6 @@ namespace EdFi.AnalyticsMiddleTier.Console
                                 case DataStandard.Ds2:
                                     install = new Ds2.Install(migrationStrategy);
                                     break;
-
                                 case DataStandard.Ds31:
                                     install = new Ds31.Install(migrationStrategy);
                                     break;
@@ -191,9 +190,6 @@ namespace EdFi.AnalyticsMiddleTier.Console
 
         [Option('u', "uninstall", Required = false, Default = false, HelpText = "Uninstall all analytics views and indexes")]
         public bool Uninstall { get; set; }
-
-        [Option("experimental", Required = false, Default = false, HelpText = "PostgreSQL is an experimental feature that has not been fully tested yet. To proceed with the install, rerun the command using switch --experimental.")]
-        public bool Experimental { get; set; }
 
         [Option('t', "timeout", Required = false, Default = 30, HelpText = "SQL Execution timeout in seconds")]
         public int TimeoutSeconds { get; set; }


### PR DESCRIPTION
# OVERVIEW 

The console would show an experimental warning. This task is to remove that.

Additionally, there was an experimental command-line option that went with postgres Beta support. This was also removed.

# TESTING

Run the console with the /? help switch and you should see the following output. Note: experimental (e) is no longer available.

When you execute for Postgres database, it should load the data without an exception.
