### PR TITLE
[BIA-492] Fixes postgres installation for DS 3.2.

### DIFF
--- a/src/EdFi.AnalyticsMiddleTier.DataStandard32/Chrab/PostgreSQL/0003-View-ChronicAbsenteeismAttendanceFact-Update.sql
+++ b/src/EdFi.AnalyticsMiddleTier.DataStandard32/Chrab/PostgreSQL/0003-View-ChronicAbsenteeismAttendanceFact-Update.sql
@@ -3,6 +3,8 @@
 -- The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 -- See the LICENSE and NOTICES files in the project root for more information.
 
+DROP VIEW IF EXISTS analytics.chrab_ChronicAbsenteeismAttendanceFact;
+
 CREATE OR REPLACE VIEW analytics.chrab_ChronicAbsenteeismAttendanceFact
 AS
 	WITH descriptorMap AS (


### PR DESCRIPTION
### Testing
If you don't have a postgres database you can use this to download it:
[ed-fi - EdFi.Suite3.Ods.Populated.Template.PostgreSQL 5.2.0-b10359](https://www.myget.org/feed/ed-fi/package/nuget/EdFi.Suite3.Ods.Populated.Template.PostgreSQL)

To test this just execute the installer on a postgres database. The installer should work fine. 
