### PR TITLE
BIA-643 Update GradingPeriodDim tests to run on Postgres

### DIFF
--- a/src/EdFi.AnalyticsMiddleTier.Tests/Dimensions/When_querying_the_GradingPeriodDim_view.cs
+++ b/src/EdFi.AnalyticsMiddleTier.Tests/Dimensions/When_querying_the_GradingPeriodDim_view.cs
@@ -13,7 +13,7 @@ using CommonLib = EdFi.AnalyticsMiddleTier.Common;
 namespace EdFi.AnalyticsMiddleTier.Tests.Dimensions.GradingPeriodDimTestGroup
 {
     [SuppressMessage("ReSharper", "InconsistentNaming")]
-    public abstract class When_querying_the_GradingPeriodDim_view : When_querying_a_view
+    public abstract class When_querying_the_GradingPeriodDim_view : When_querying_a_view_postgres
     {
         protected const string TestCasesFolder = "TestCases.GradingPeriodDim";
         protected const string TestCasesDataFileName = "0000_GradingPeriodDim_Data_Load.xml";

--- a/src/EdFi.AnalyticsMiddleTier.Tests/Dimensions/When_querying_the_GradingPeriodDim_view.cs
+++ b/src/EdFi.AnalyticsMiddleTier.Tests/Dimensions/When_querying_the_GradingPeriodDim_view.cs
@@ -186,5 +186,19 @@ namespace EdFi.AnalyticsMiddleTier.Tests.Dimensions.GradingPeriodDimTestGroup
             }
         }
 
+        public class Given_grading_period_54_628530001_21001120
+        : When_querying_the_GradingPeriodDim_view
+        {
+            public Given_grading_period_54_628530001_21001120(TestHarnessBase dataStandard) => SetDataStandard(dataStandard);
+            private string _caseIdentifier = "54_628530001_21001120";
+
+            [Test]
+            public void Then_should_return_zero_records()
+            {
+                (bool success, string errorMessage) testResult = DataStandard.RunTestCase<CountResult>($"{TestCasesFolder}.{_caseIdentifier}_should_return_zero_records.xml");
+                testResult.success.ShouldBe(true, testResult.errorMessage);
+            }
+        }
+
     }
 }

--- a/src/EdFi.AnalyticsMiddleTier.Tests/TestCases/GradingPeriodDim/54_628530001_21001120_should_return_zero_records.xml
+++ b/src/EdFi.AnalyticsMiddleTier.Tests/TestCases/GradingPeriodDim/54_628530001_21001120_should_return_zero_records.xml
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<TestCase>
+  <DBMS>Any</DBMS>
+  <ControlDataInsertion>
+  </ControlDataInsertion>
+  <Query>
+    SELECT COUNT(1) AS CountValue
+    FROM analytics.GradingPeriodDim
+    WHERE GradingPeriodKey = '54-628530001-21001120';
+  </Query>
+  <Result>
+  <CountValue>0</CountValue>
+</Result>
+</TestCase>

--- a/src/EdFi.AnalyticsMiddleTier.Tests/TestCases/GradingPeriodDim/MSSQL/v_2/0000_GradingPeriodDim_Data_Load.xml
+++ b/src/EdFi.AnalyticsMiddleTier.Tests/TestCases/GradingPeriodDim/MSSQL/v_2/0000_GradingPeriodDim_Data_Load.xml
@@ -366,5 +366,35 @@ INSERT INTO [edfi].[GradingPeriod]
               AND [BeginDate] = '2011-11-20'
     )
 );
+INSERT INTO [edfi].[GradingPeriod]
+(GradingPeriodDescriptorId, 
+ SchoolId, 
+ BeginDate, 
+ TotalInstructionalDays, 
+ EndDate, 
+ PeriodSequence, 
+ Id, 
+ LastModifiedDate, 
+ CreateDate
+)
+(
+    SELECT TOP 1 '54', 
+                 '628530001', 
+                 '2100-11-20', 
+                 '27', 
+                 '2100-12-30', 
+                 NULL, 
+                 '557EE073-9E3D-4B92-B832-FA9266CD7D27', 
+                 'Sep 18 2100 11:34AM', 
+                 'Sep 18 2100 11:34AM'
+    WHERE NOT EXISTS
+    (
+        SELECT 1
+        FROM [edfi].[GradingPeriod]
+        WHERE [GradingPeriodDescriptorId] = 54
+              AND [SchoolId] = 628530001
+              AND [BeginDate] = '2100-11-20'
+    )
+);
 	</ControlDataInsertion>
 </TestCase>

--- a/src/EdFi.AnalyticsMiddleTier.Tests/TestCases/GradingPeriodDim/MSSQL/v_3_1/0000_GradingPeriodDim_Data_Load.xml
+++ b/src/EdFi.AnalyticsMiddleTier.Tests/TestCases/GradingPeriodDim/MSSQL/v_3_1/0000_GradingPeriodDim_Data_Load.xml
@@ -223,6 +223,12 @@
           '2011','2010-2011','0','1926BB96-BF8C-493A-93BD-A8E60DBC83E2','Jun 19 2015 11:40AM','Jun 19 2015 11:40AM'
           WHERE NOT EXISTS(SELECT 1 FROM edfi.SchoolYearType WHERE SchoolYear= '2011'));
 
+      INSERT INTO edfi.SchoolYearType(
+          SchoolYear,SchoolYearDescription,CurrentSchoolYear,Id,LastModifiedDate,CreateDate)
+          (SELECT 
+          '2100','2099-2100','0','1926BB96-BF8C-493A-93BD-A8E60DBC83E3','Jun 19 2100 11:40AM','Jun 19 2100 11:40AM'
+          WHERE NOT EXISTS(SELECT 1 FROM edfi.SchoolYearType WHERE SchoolYear= '2100'));
+
       INSERT INTO edfi.GradingPeriod
       (GradingPeriodDescriptorId,SchoolId,SchoolYear,BeginDate,TotalInstructionalDays,EndDate,PeriodSequence,Id,LastModifiedDate,CreateDate)
       (
@@ -256,6 +262,24 @@
                        'Sep 18 2015 11:34AM'
           WHERE NOT EXISTS (
               SELECT 1 FROM edfi.GradingPeriod WHERE GradingPeriodDescriptorId = 54 AND SchoolId = 628530001 AND BeginDate = '2011-11-20'
+          )
+      );
+
+      INSERT INTO edfi.GradingPeriod
+	      (GradingPeriodDescriptorId,SchoolId,SchoolYear,BeginDate,TotalInstructionalDays,EndDate,PeriodSequence,Id,LastModifiedDate,CreateDate)
+      (
+          SELECT TOP 1 '54', 
+                       '628530001', 
+				                2100,
+                       '2100-11-20', 
+                       '27', 
+                       '2100-12-30', 
+                       '2', 
+                       '557EE073-9E3D-4B92-B832-FA9266CD7D27', 
+                       'Sep 18 2100 11:34AM', 
+                       'Sep 18 2100 11:34AM'
+          WHERE NOT EXISTS (
+              SELECT 1 FROM edfi.GradingPeriod WHERE GradingPeriodDescriptorId = 54 AND SchoolId = 628530001 AND BeginDate = '2100-11-20'
           )
       );
 

--- a/src/EdFi.AnalyticsMiddleTier.Tests/TestCases/GradingPeriodDim/PostgreSQL/v_3_2/0000_GradingPeriodDim_Data_Load.xml
+++ b/src/EdFi.AnalyticsMiddleTier.Tests/TestCases/GradingPeriodDim/PostgreSQL/v_3_2/0000_GradingPeriodDim_Data_Load.xml
@@ -215,6 +215,12 @@
           '2011','2010-2011','0','1926BB96-BF8C-493A-93BD-A8E60DBC83E2','Jun 19 2015 11:40AM','Jun 19 2015 11:40AM'
           WHERE NOT EXISTS(SELECT 1 FROM edfi.SchoolYearType WHERE SchoolYear= '2011'));
 
+      INSERT INTO edfi.SchoolYearType(
+          SchoolYear,SchoolYearDescription,CurrentSchoolYear,Id,LastModifiedDate,CreateDate)
+          (SELECT 
+          '2100','2099-2100','0','1926BB96-BF8C-493A-93BD-A8E60DBC83E3','Jun 19 2100 11:40AM','Jun 19 2100 11:40AM'
+          WHERE NOT EXISTS(SELECT 1 FROM edfi.SchoolYearType WHERE SchoolYear= '2100'));
+
       INSERT INTO edfi.GradingPeriod
       (GradingPeriodDescriptorId,SchoolId,SchoolYear,BeginDate,TotalInstructionalDays,EndDate,PeriodSequence,Id,LastModifiedDate,CreateDate)
       (
@@ -251,5 +257,22 @@
           )
       );
 
+      INSERT INTO edfi.GradingPeriod
+	      (GradingPeriodDescriptorId,SchoolId,SchoolYear,BeginDate,TotalInstructionalDays,EndDate,PeriodSequence,Id,LastModifiedDate,CreateDate)
+      (
+          SELECT '54', 
+                       '628530001', 
+				                2100,
+                       '2100-11-20', 
+                       '27', 
+                       '2100-12-30', 
+                       '2', 
+                       '557EE073-9E3D-4B92-B832-FA9266CD7D27', 
+                       'Sep 18 2100 11:34AM', 
+                       'Sep 18 2100 11:34AM'
+          WHERE NOT EXISTS (
+              SELECT 1 FROM edfi.GradingPeriod WHERE GradingPeriodDescriptorId = 54 AND SchoolId = 628530001 AND BeginDate = '2100-11-20'
+          )
+      );
 	</ControlDataInsertion>
 </TestCase>

--- a/src/EdFi.AnalyticsMiddleTier.Tests/TestCases/GradingPeriodDim/PostgreSQL/v_3_2/0000_GradingPeriodDim_Data_Load.xml
+++ b/src/EdFi.AnalyticsMiddleTier.Tests/TestCases/GradingPeriodDim/PostgreSQL/v_3_2/0000_GradingPeriodDim_Data_Load.xml
@@ -1,0 +1,255 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<TestCase>
+	<DBMS>Any</DBMS>
+	<ControlDataInsertion>
+         
+      INSERT INTO edfi.EducationOrganization
+	      (EducationOrganizationId,NameOfInstitution,ShortNameOfInstitution,WebSite,OperationalStatusDescriptorId,Discriminator,CreateDate,LastModifiedDate,Id)
+      (
+          SELECT '628530', 
+                       'Lander ISD', 
+                       NULL, 
+                       NULL, 
+                       NULL, 
+				               'edfi.LocalEducationAgency',
+                       'Sep 18 2015 11:34AM', 
+                       'Sep 18 2015 11:34AM',
+                       '13CC7674-8E27-443F-88B8-F8FDDD4601F1' 
+          WHERE NOT EXISTS (
+              SELECT 1 FROM edfi.EducationOrganization WHERE EducationOrganizationId = 628530
+          )
+      ); 
+
+      INSERT INTO edfi.EducationOrganization
+	      (EducationOrganizationId,NameOfInstitution,ShortNameOfInstitution,WebSite,OperationalStatusDescriptorId,Discriminator,CreateDate,LastModifiedDate,Id)
+      (
+          SELECT '628530001', 
+                       'Lander Middle', 
+                       NULL, 
+                       NULL, 
+                       NULL, 
+				               'edfi.School',
+                       'Sep 18 2015 11:34AM', 
+                       'Sep 18 2015 11:34AM',
+                       '4E368F85-6A25-42F3-8D61-D972C421AC58'
+          WHERE NOT EXISTS (
+              SELECT 1 FROM edfi.EducationOrganization WHERE EducationOrganizationId = 628530001
+          )
+      ); 
+
+      INSERT INTO edfi.EducationOrganization
+	      (EducationOrganizationId,NameOfInstitution,ShortNameOfInstitution,WebSite,OperationalStatusDescriptorId,Discriminator,CreateDate,LastModifiedDate,Id)
+      (
+          SELECT '152950', 
+                       'ESC Region 17', 
+                       NULL, 
+                       NULL, 
+                       NULL, 
+				              'edfi.EducationServiceCenter',
+                       'Sep 18 2015 11:34AM', 
+                       'Sep 18 2015 11:34AM',
+                       '03DE6F94-316A-4B06-8C67-2C8748DCA1A9'
+          WHERE NOT EXISTS (
+              SELECT 1 FROM edfi.EducationOrganization WHERE EducationOrganizationId = 152950
+          )
+      ); 
+
+      INSERT INTO edfi.EducationServiceCenter
+	      (EducationServiceCenterId,StateEducationAgencyId)
+      (
+          SELECT '152950', 
+                       NULL
+          WHERE NOT EXISTS (
+              SELECT 1 FROM edfi.EducationServiceCenter WHERE EducationServiceCenterId = 152950
+          )
+      );
+
+      INSERT INTO edfi.descriptor
+	      (DescriptorId,Namespace,CodeValue,ShortDescription,Description,PriorDescriptorId,EffectiveBeginDate,EffectiveEndDate,Id,LastModifiedDate,CreateDate)
+      (
+          SELECT 
+		        '835', 
+		        'uri://ed-fi.org/CharterStatusDescriptor', 
+		        'School Charter', 
+		        'School Charter',
+		        'School Charter', 
+		        NULL, 
+		        NULL, 
+		        NULL, 
+		        '8C058748-9083-4B68-9E9B-A6F339B87009', 
+		        'Jun 19 2015 11:41AM', 
+		        'Jun 19 2015 11:41AM'
+          WHERE NOT EXISTS (
+		      SELECT 1 FROM edfi.descriptor WHERE descriptorid = 835
+	      )
+      );
+
+      INSERT INTO edfi.CharterStatusDescriptor (CharterStatusDescriptorId)
+      (
+          SELECT 835
+          WHERE NOT EXISTS (
+		         SELECT 1 FROM edfi.CharterStatusDescriptor WHERE CharterStatusDescriptorId = 835
+	      )
+      );
+
+      INSERT INTO edfi.descriptor
+	      (DescriptorId,Namespace,CodeValue,ShortDescription,Description,PriorDescriptorId,EffectiveBeginDate,EffectiveEndDate,Id,LastModifiedDate,CreateDate)
+      (
+          SELECT 
+		        '1086', 
+		        'uri://ed-fi.org/LocalEducationAgencyCategoryDescriptor', 
+		        'Independent', 
+		        'Independent',
+		        'Independent', 
+		        NULL, 
+		        NULL, 
+		        NULL, 
+		        '0A65B4F5-49CC-4ABD-9A3F-41FFA09EF2B3', 
+		        'Jun 19 2015 11:42AM', 
+		        'Jun 19 2015 11:42AM'
+          WHERE NOT EXISTS (
+		        SELECT 1 FROM edfi.descriptor WHERE descriptorid = 1086
+	      )
+      );
+
+      INSERT INTO edfi.LocalEducationAgencyCategoryDescriptor (LocalEducationAgencyCategoryDescriptorId)
+      (
+          SELECT 1086
+          WHERE NOT EXISTS (
+		        SELECT 1 FROM edfi.LocalEducationAgencyCategoryDescriptor WHERE LocalEducationAgencyCategoryDescriptorId = 1086
+	      )
+      );
+
+      INSERT INTO edfi.LocalEducationAgency
+	      (LocalEducationAgencyId,LocalEducationAgencyCategoryDescriptorId,CharterStatusDescriptorId,ParentLocalEducationAgencyId,EducationServiceCenterId,StateEducationAgencyId)
+      (
+          SELECT '628530', 
+                       '1086', 
+                       '835', 
+                       NULL, 
+                       '152950', 
+                       NULL
+          WHERE NOT EXISTS (
+              SELECT 1 FROM edfi.LocalEducationAgency WHERE LocalEducationAgencyId = 628530
+          )
+      );
+
+      INSERT INTO edfi.descriptor
+	      (DescriptorId,Namespace,CodeValue,ShortDescription,Description,PriorDescriptorId,EffectiveBeginDate,EffectiveEndDate,Id,LastModifiedDate,CreateDate)
+      (
+          SELECT 
+		        '1695', 
+		        'uri://ed-fi.org/SchoolTypeDescriptor', 
+		        'Special Education', 
+		        'Special Education',
+		        'Special Education', 
+		        NULL, 
+		        NULL, 
+		        NULL, 
+		        '66CB3836-E555-45F0-A819-FE264BDE181B', 
+		        'Jun 19 2015 11:41AM', 
+		        'Jun 19 2015 11:41AM'
+          WHERE NOT EXISTS (
+		      SELECT 1 FROM edfi.descriptor WHERE descriptorid = 1695
+	      )
+      );
+
+      INSERT INTO edfi.SchoolTypeDescriptor (SchoolTypeDescriptorId)
+      (
+          SELECT 1695
+          WHERE NOT EXISTS (
+		        SELECT 1 FROM edfi.SchoolTypeDescriptor WHERE SchoolTypeDescriptorId = 1695
+	      )
+      );
+
+      INSERT INTO edfi.school
+	      (SchoolId,SchoolTypeDescriptorId,CharterStatusDescriptorId,TitleIPartASchoolDesignationDescriptorId,MagnetSpecialProgramEmphasisSchoolDescriptorId, 
+		      AdministrativeFundingControlDescriptorId,InternetAccessDescriptorId,LocalEducationAgencyId,CharterApprovalAgencyTypeDescriptorId,CharterApprovalSchoolYear)
+      (
+          SELECT '628530001', 
+                       NULL, 
+                       '835', 
+                       NULL, 
+                       NULL, 
+                       NULL, 
+                       NULL, 
+				               '628530',
+                       NULL, 
+                       NULL
+          WHERE NOT EXISTS (
+              SELECT 1 FROM edfi.school WHERE SchoolId = 628530001
+          )
+      );
+
+      INSERT INTO edfi.descriptor
+	      (DescriptorId,Namespace,CodeValue,ShortDescription,Description,PriorDescriptorId,EffectiveBeginDate,EffectiveEndDate,Id,LastModifiedDate,CreateDate)
+      (
+          SELECT 
+		        '54', 
+		        'uri://ed-fi.org/GradingPeriodDescriptor', 
+		        'First Six Weeks', 
+		        'First Six Weeks',
+		        'First Six Weeks', 
+		        NULL, 
+		        NULL, 
+		        NULL, 
+		        'ABE1098D-9723-48ED-AA29-BEF3E458FC5E', 
+		        'Jun 19 2015 11:41AM', 
+		        'Jun 19 2015 11:41AM'
+          WHERE NOT EXISTS (
+		        SELECT 1 FROM edfi.descriptor WHERE descriptorid = 54
+	      )
+      );
+
+      INSERT INTO edfi.GradingPeriodDescriptor (GradingPeriodDescriptorId)
+      (
+          SELECT '54'
+          WHERE NOT EXISTS (
+              SELECT 1 FROM edfi.GradingPeriodDescriptor WHERE GradingPeriodDescriptorid = 54
+          )
+      ); 
+
+      INSERT INTO edfi.SchoolYearType(
+          SchoolYear,SchoolYearDescription,CurrentSchoolYear,Id,LastModifiedDate,CreateDate)
+          (SELECT 
+          '2011','2010-2011','0','1926BB96-BF8C-493A-93BD-A8E60DBC83E2','Jun 19 2015 11:40AM','Jun 19 2015 11:40AM'
+          WHERE NOT EXISTS(SELECT 1 FROM edfi.SchoolYearType WHERE SchoolYear= '2011'));
+
+      INSERT INTO edfi.GradingPeriod
+      (GradingPeriodDescriptorId,SchoolId,SchoolYear,BeginDate,TotalInstructionalDays,EndDate,PeriodSequence,Id,LastModifiedDate,CreateDate)
+      (
+          SELECT '54', 
+                       '628530001', 
+				               2011,
+                       '2011-08-22', 
+                       '29', 
+                       '2011-09-30', 
+                       '1', 
+                       '0488184B-5AAC-4D54-838B-B180D53CD136', 
+                       'Sep 18 2015 11:34AM', 
+                       'Sep 18 2015 11:34AM'
+          WHERE NOT EXISTS (
+              SELECT 1 FROM edfi.GradingPeriod WHERE GradingPeriodDescriptorId = 54 AND SchoolId = 628530001 AND BeginDate = '2011-08-22'
+          )
+      ); 
+
+      INSERT INTO edfi.GradingPeriod
+	      (GradingPeriodDescriptorId,SchoolId,SchoolYear,BeginDate,TotalInstructionalDays,EndDate,PeriodSequence,Id,LastModifiedDate,CreateDate)
+      (
+          SELECT '54', 
+                       '628530001', 
+				                2011,
+                       '2011-11-20', 
+                       '27', 
+                       '2011-12-30', 
+                       '2', 
+                       '557EE073-9E3D-4B92-B832-FA9266CD7D26', 
+                       'Sep 18 2015 11:34AM', 
+                       'Sep 18 2015 11:34AM'
+          WHERE NOT EXISTS (
+              SELECT 1 FROM edfi.GradingPeriod WHERE GradingPeriodDescriptorId = 54 AND SchoolId = 628530001 AND BeginDate = '2011-11-20'
+          )
+      );
+
+	</ControlDataInsertion>
+</TestCase>

--- a/src/EdFi.AnalyticsMiddleTier.Tests/TestCases/GradingPeriodDim/PostgreSQL/v_3_2/0001_GradingPeriodDim_should_match_column_dictionary.xml
+++ b/src/EdFi.AnalyticsMiddleTier.Tests/TestCases/GradingPeriodDim/PostgreSQL/v_3_2/0001_GradingPeriodDim_should_match_column_dictionary.xml
@@ -1,0 +1,49 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<TestCase>
+    <DBMS>Any</DBMS>
+    <ControlDataInsertion>
+    </ControlDataInsertion>
+    <Query>
+        SELECT column_name AS columnname,
+        udt_name AS datatype
+        FROM information_schema.columns
+        WHERE table_schema = 'analytics'
+        AND table_name = 'gradingperioddim'
+    </Query>
+    <Result>
+        <ColumnName>GradingPeriodKey</ColumnName>
+        <DataType>text</DataType>
+    </Result>
+    <Result>
+        <ColumnName>GradingPeriodBeginDateKey</ColumnName>
+        <DataType>text</DataType>
+    </Result>
+    <Result>
+        <ColumnName>GradingPeriodEndDateKey</ColumnName>
+        <DataType>text</DataType>
+    </Result>
+    <Result>
+        <ColumnName>GradingPeriodDescription</ColumnName>
+        <DataType>text</DataType>
+    </Result>
+    <Result>
+        <ColumnName>TotalInstructionalDays</ColumnName>
+        <DataType>int4</DataType>
+    </Result>
+    <Result>
+        <ColumnName>PeriodSequence</ColumnName>
+        <DataType>int4</DataType>
+    </Result>
+    <Result>
+        <ColumnName>SchoolKey</ColumnName>
+        <DataType>text</DataType>
+    </Result>
+    <Result>
+        <ColumnName>SchoolYear</ColumnName>
+        <DataType>text</DataType>
+    </Result>
+    <Result>
+        <ColumnName>LastModifiedDate</ColumnName>
+        <DataType>timestamp</DataType>
+    </Result>
+</TestCase>

--- a/src/EdFi.AnalyticsMiddleTier.Tests/TestCases/GradingPeriodDim/PostgreSQL/v_3_2/0001_GradingPeriodDim_should_match_column_dictionary.xml
+++ b/src/EdFi.AnalyticsMiddleTier.Tests/TestCases/GradingPeriodDim/PostgreSQL/v_3_2/0001_GradingPeriodDim_should_match_column_dictionary.xml
@@ -11,39 +11,39 @@
         AND table_name = 'gradingperioddim'
     </Query>
     <Result>
-        <ColumnName>GradingPeriodKey</ColumnName>
+        <ColumnName>gradingperiodkey</ColumnName>
         <DataType>text</DataType>
     </Result>
     <Result>
-        <ColumnName>GradingPeriodBeginDateKey</ColumnName>
+        <ColumnName>gradingperiodbegindatekey</ColumnName>
         <DataType>text</DataType>
     </Result>
     <Result>
-        <ColumnName>GradingPeriodEndDateKey</ColumnName>
+        <ColumnName>gradingperiodenddatekey</ColumnName>
         <DataType>text</DataType>
     </Result>
     <Result>
-        <ColumnName>GradingPeriodDescription</ColumnName>
-        <DataType>text</DataType>
+        <ColumnName>gradingperioddescription</ColumnName>
+        <DataType>varchar</DataType>
     </Result>
     <Result>
-        <ColumnName>TotalInstructionalDays</ColumnName>
+        <ColumnName>totalinstructionaldays</ColumnName>
         <DataType>int4</DataType>
     </Result>
     <Result>
-        <ColumnName>PeriodSequence</ColumnName>
+        <ColumnName>periodsequence</ColumnName>
         <DataType>int4</DataType>
     </Result>
     <Result>
-        <ColumnName>SchoolKey</ColumnName>
-        <DataType>text</DataType>
+        <ColumnName>schoolkey</ColumnName>
+        <DataType>varchar</DataType>
     </Result>
     <Result>
-        <ColumnName>SchoolYear</ColumnName>
-        <DataType>text</DataType>
+        <ColumnName>schoolyear</ColumnName>
+        <DataType>varchar</DataType>
     </Result>
     <Result>
-        <ColumnName>LastModifiedDate</ColumnName>
+        <ColumnName>lastmodifieddate</ColumnName>
         <DataType>timestamp</DataType>
     </Result>
 </TestCase>


### PR DESCRIPTION
The GradingPeriodDim tests will now run against Postgres for DataStandard32 only. They have their own copy of the data insert script along and with a schema xml file, which had modifications made to match how things need to work in Postgres with being all lowercase for columns, updated datatypes for the columns, and removing top 1 from the select queries.