### PR TITLE
BIA-817 - Change build agent script logic to work for Postgres v11

### DIFF
--- a/eng/CreateTestDbAndSchema.ps1
+++ b/eng/CreateTestDbAndSchema.ps1
@@ -3,14 +3,9 @@
 # The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 # See the LICENSE and NOTICES files in the project root for more information.
 
-$dburl="postgresql://postgres@localhost:5432/postgres"
-$data="SELECT datname FROM pg_catalog.pg_database WHERE lower(datname) = lower('EdFi_Ods_Tests');" | psql --csv $dburl | ConvertFrom-Csv
-if ($data.datname -eq $null) {
-    Write-Host "No db found, creating db first"
-    psql -h localhost -p 5432 -U postgres -c "CREATE DATABASE edfi_ods_tests;"
-    Write-Host "Running migration on db"
-    psql -d edfi_ods_tests -h localhost -p 5432 -U postgres -f .\src\EdFi.AnalyticsMiddleTier.Tests\EdFi.Ods.Minimal.Template.sql
-}
-else {
-    Write-Host "db found, not running script"
-}
+Write-Host "dropping db if it exists"
+psql -h localhost -p 5432 -U postgres -c "DROP DATABASE IF EXISTS edfi_ods_tests;"
+Write-Host "creating db"
+psql -h localhost -p 5432 -U postgres -c "CREATE DATABASE edfi_ods_tests;"
+Write-Host "Running migration on db"
+psql -d edfi_ods_tests -h localhost -p 5432 -U postgres -f .\src\EdFi.AnalyticsMiddleTier.Tests\EdFi.Ods.Minimal.Template.sql


### PR DESCRIPTION
The previous version of this script relied on the --csv flag to export the results of a query to csv and then parse it. This flag was added in Postgres v12, which we do not currently support and is not installed on all build agents. Now instead this script is simpler and drops the db if it exists, and then re-creates it and runs the sql script to populate it.