### PR TITLE
BIA-808 - Adding StudentSchoolKey to StudentSectionDim view

### DIFF
--- a/src/EdFi.AnalyticsMiddleTier.DataStandard2/Base/MSSQL/0036-View-StudentSectionDim-Alter.sql
+++ b/src/EdFi.AnalyticsMiddleTier.DataStandard2/Base/MSSQL/0036-View-StudentSectionDim-Alter.sql
@@ -1,0 +1,69 @@
+﻿-- SPDX-License-Identifier: Apache-2.0
+-- Licensed to the Ed-Fi Alliance under one or more agreements.
+-- The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+-- See the LICENSE and NOTICES files in the project root for more information.
+
+
+IF EXISTS
+(
+    SELECT 1
+    FROM [INFORMATION_SCHEMA].[VIEWS]
+    WHERE [TABLE_SCHEMA] = 'analytics'
+          AND [TABLE_NAME] = 'StudentSectionDim'
+)
+    BEGIN
+        DROP VIEW [analytics].[StudentSectionDim];
+END;
+GO
+CREATE VIEW [analytics].[StudentSectionDim]
+AS
+     SELECT CAST([Student].[StudentUniqueId] AS NVARCHAR) + '-' + CAST([StudentSectionAssociation].[SchoolId] AS NVARCHAR) + '-' + [StudentSectionAssociation].[ClassPeriodName] + '-' + [StudentSectionAssociation].[ClassroomIdentificationCode] + '-' + [StudentSectionAssociation].[LocalCourseCode] + '-' + CAST([StudentSectionAssociation].[TermDescriptorId] AS NVARCHAR) + '-' + CAST([StudentSectionAssociation].[SchoolYear] AS NVARCHAR) + '-' + [StudentSectionAssociation].[UniqueSectionCode] + '-' + CAST([StudentSectionAssociation].[SequenceOfCourse] AS NVARCHAR) + '-' + CONVERT(NVARCHAR, [StudentSectionAssociation].[BeginDate], 112) AS [StudentSectionKey],
+            CAST(Student.StudentUniqueId AS NVARCHAR) + '-' + CAST(StudentSectionAssociation.SchoolId AS NVARCHAR) AS [StudentSchoolKey],
+            [Student].[StudentUniqueId] AS [StudentKey],
+            CAST([StudentSectionAssociation].[SchoolId] AS NVARCHAR) + '-' + [StudentSectionAssociation].[ClassPeriodName] + '-' + [StudentSectionAssociation].[ClassroomIdentificationCode] + '-' + [StudentSectionAssociation].[LocalCourseCode] + '-' + CAST([StudentSectionAssociation].[TermDescriptorId] AS NVARCHAR) + '-' + CAST([StudentSectionAssociation].[SchoolYear] AS NVARCHAR) + '-' + [StudentSectionAssociation].[UniqueSectionCode] + '-' + CAST([StudentSectionAssociation].[SequenceOfCourse] AS NVARCHAR) AS [SectionKey],
+            [StudentSectionAssociation].[LocalCourseCode],
+            ISNULL([Descriptor].[Description], '') AS [Subject],
+            ISNULL([Course].[CourseTitle], '') AS [CourseTitle],
+
+            -- There could be multiple teachers for a section - reduce those to a single string.
+            -- Unfortunately this means that the Staff and StaffSectionAssociation
+            -- LastModifiedDate values can't be used to calculate this record's LastModifiedDate
+            ISNULL(STUFF(
+     (
+         SELECT N', ' + ISNULL([Staff].[FirstName], '') + ' ' + ISNULL([Staff].[LastSurname], '')
+         FROM [edfi].[StaffSectionAssociation]
+              LEFT OUTER JOIN [edfi].[Staff]
+              ON [StaffSectionAssociation].[StaffUSI] = [Staff].[StaffUSI]
+         WHERE [StudentSectionAssociation].[SchoolId] = [StaffSectionAssociation].[SchoolId]
+               AND [StudentSectionAssociation].[ClassPeriodName] = [StaffSectionAssociation].[ClassPeriodName]
+               AND [StudentSectionAssociation].[ClassroomIdentificationCode] = [StaffSectionAssociation].[ClassroomIdentificationCode]
+               AND [StudentSectionAssociation].[LocalCourseCode] = [StaffSectionAssociation].[LocalCourseCode]
+               AND [StudentSectionAssociation].[TermDescriptorId] = [StaffSectionAssociation].[TermDescriptorId]
+               AND [StudentSectionAssociation].[SchoolYear] = [StaffSectionAssociation].[SchoolYear]
+               AND [StudentSectionAssociation].[UniqueSectionCode] = [StaffSectionAssociation].[UniqueSectionCode]
+               AND [StudentSectionAssociation].[SequenceOfCourse] = [StaffSectionAssociation].[SequenceOfCourse] FOR XML PATH('')
+     ), 1, 1, N''), '') AS [TeacherName],
+            CONVERT(NVARCHAR, [StudentSectionAssociation].[BeginDate], 112) AS [StudentSectionStartDateKey],
+            CONVERT(NVARCHAR, [StudentSectionAssociation].[EndDate], 112) AS [StudentSectionEndDateKey],
+            CAST([StudentSectionAssociation].[SchoolId] AS VARCHAR) AS [SchoolKey],
+            CAST(StudentSectionAssociation.SchoolYear AS NVARCHAR) AS SchoolYear,
+     (
+         SELECT MAX([MaxLastModifiedDate])
+         FROM(VALUES([StudentSectionAssociation].[LastModifiedDate]), ([Course].[LastModifiedDate]), ([CourseOffering].[LastModifiedDate]), ([Descriptor].[LastModifiedDate])) AS VALUE([MaxLastModifiedDate])
+     ) AS [LastModifiedDate]
+     FROM [edfi].[StudentSectionAssociation]
+          INNER JOIN [edfi].[Student]
+          ON [StudentSectionAssociation].[StudentUSI] = [Student].[StudentUSI]
+          INNER JOIN [edfi].[CourseOffering]
+          ON [CourseOffering].[SchoolId] = [StudentSectionAssociation].[SchoolId]
+             AND [CourseOffering].[LocalCourseCode] = [StudentSectionAssociation].[LocalCourseCode]
+             AND [CourseOffering].[TermDescriptorId] = [StudentSectionAssociation].[TermDescriptorId]
+             AND [CourseOffering].[SchoolYear] = [StudentSectionAssociation].[SchoolYear]
+          INNER JOIN [edfi].[Course]
+          ON [Course].[CourseCode] = [CourseOffering].[CourseCode]
+             AND [Course].[EducationOrganizationId] = [CourseOffering].[EducationOrganizationId]
+          LEFT OUTER JOIN [edfi].[AcademicSubjectDescriptor]
+          ON [AcademicSubjectDescriptor].[AcademicSubjectDescriptorId] = [Course].[AcademicSubjectDescriptorId]
+          LEFT OUTER JOIN [edfi].[Descriptor]
+          ON [AcademicSubjectDescriptor].[AcademicSubjectDescriptorId] = [Descriptor].[DescriptorId]
+GO

--- a/src/EdFi.AnalyticsMiddleTier.DataStandard31/Base/MSSQL/0037-View-StudentSectionDim-Alter.sql
+++ b/src/EdFi.AnalyticsMiddleTier.DataStandard31/Base/MSSQL/0037-View-StudentSectionDim-Alter.sql
@@ -1,0 +1,72 @@
+﻿-- SPDX-License-Identifier: Apache-2.0
+-- Licensed to the Ed-Fi Alliance under one or more agreements.
+-- The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+-- See the LICENSE and NOTICES files in the project root for more information.
+
+
+IF EXISTS
+(
+    SELECT 
+           1
+    FROM INFORMATION_SCHEMA.VIEWS
+    WHERE TABLE_SCHEMA = 'analytics'
+          AND TABLE_NAME = 'StudentSectionDim'
+)
+    BEGIN
+        DROP VIEW 
+             analytics.StudentSectionDim;
+END;
+GO
+CREATE VIEW analytics.StudentSectionDim
+AS
+     SELECT 
+            CAST(Student.StudentUniqueId AS NVARCHAR) + '-' + CAST(StudentSectionAssociation.SchoolId AS NVARCHAR) + '-' + StudentSectionAssociation.LocalCourseCode + '-' + CAST(StudentSectionAssociation.SchoolYear AS NVARCHAR) + '-' + StudentSectionAssociation.SectionIdentifier + '-' + StudentSectionAssociation.SessionName + '-' + CONVERT(NVARCHAR, StudentSectionAssociation.BeginDate, 112) AS StudentSectionKey, 
+            CAST(Student.StudentUniqueId AS NVARCHAR) + '-' + CAST(StudentSectionAssociation.SchoolId AS NVARCHAR) AS StudentSchoolKey,
+            Student.StudentUniqueId AS StudentKey, 
+            CAST(StudentSectionAssociation.SchoolId AS NVARCHAR) + '-' + StudentSectionAssociation.LocalCourseCode + '-' + CAST(StudentSectionAssociation.SchoolYear AS NVARCHAR) + '-' + StudentSectionAssociation.SectionIdentifier + '-' + StudentSectionAssociation.SessionName AS SectionKey, 
+            StudentSectionAssociation.LocalCourseCode, 
+            ISNULL(AcademicSubjectType.Description, '') AS Subject, 
+            ISNULL(Course.CourseTitle, '') AS CourseTitle,
+
+            -- There could be multiple teachers for a section - reduce those to a single string.
+            -- Unfortunately this means that the Staff and StaffSectionAssociation
+            -- LastModifiedDate values can't be used to calculate this record's LastModifiedDate
+            ISNULL(STUFF(
+     (
+         SELECT 
+                N', ' + ISNULL(Staff.FirstName, '') + ' ' + ISNULL(Staff.LastSurname, '')
+         FROM edfi.StaffSectionAssociation
+              LEFT OUTER JOIN edfi.Staff
+              ON StaffSectionAssociation.StaffUSI = Staff.StaffUSI
+         WHERE StudentSectionAssociation.SchoolId = StaffSectionAssociation.SchoolId
+               AND StudentSectionAssociation.LocalCourseCode = StaffSectionAssociation.LocalCourseCode
+               AND StudentSectionAssociation.SchoolYear = StaffSectionAssociation.SchoolYear
+               AND StudentSectionAssociation.SectionIdentifier = StaffSectionAssociation.SectionIdentifier
+               AND StudentSectionAssociation.SessionName = StaffSectionAssociation.SessionName FOR
+         XML PATH('')
+     ), 1, 1, N''), '') AS TeacherName, 
+            CONVERT(NVARCHAR, StudentSectionAssociation.BeginDate, 112) AS StudentSectionStartDateKey, 
+            CONVERT(NVARCHAR, StudentSectionAssociation.EndDate, 112) AS StudentSectionEndDateKey, 
+            CAST(StudentSectionAssociation.SchoolId AS VARCHAR) AS SchoolKey, 
+            CAST(StudentSectionAssociation.SchoolYear AS NVARCHAR) AS SchoolYear,
+     (
+         SELECT 
+                MAX(MaxLastModifiedDate)
+         FROM(VALUES(StudentSectionAssociation.LastModifiedDate), (Course.LastModifiedDate), (CourseOffering.LastModifiedDate), (AcademicSubjectType.LastModifiedDate)) AS VALUE(MaxLastModifiedDate)
+     ) AS LastModifiedDate
+     FROM edfi.StudentSectionAssociation
+          INNER JOIN edfi.Student
+          ON StudentSectionAssociation.StudentUSI = Student.StudentUSI
+          INNER JOIN edfi.CourseOffering
+          ON CourseOffering.SchoolId = StudentSectionAssociation.SchoolId
+             AND CourseOffering.LocalCourseCode = StudentSectionAssociation.LocalCourseCode
+             AND CourseOffering.SchoolYear = StudentSectionAssociation.SchoolYear
+             AND CourseOffering.SessionName = StudentSectionAssociation.SessionName
+          INNER JOIN edfi.Course
+          ON Course.CourseCode = CourseOffering.CourseCode
+             AND Course.EducationOrganizationId = CourseOffering.EducationOrganizationId
+          LEFT OUTER JOIN edfi.AcademicSubjectDescriptor
+          ON AcademicSubjectDescriptor.AcademicSubjectDescriptorId = Course.AcademicSubjectDescriptorId
+          LEFT OUTER JOIN edfi.Descriptor AS AcademicSubjectType
+          ON AcademicSubjectType.DescriptorId = AcademicSubjectDescriptor.AcademicSubjectDescriptorId;
+GO

--- a/src/EdFi.AnalyticsMiddleTier.DataStandard32/Base/MSSQL/0037-View-StudentSectionDim-Alter.sql
+++ b/src/EdFi.AnalyticsMiddleTier.DataStandard32/Base/MSSQL/0037-View-StudentSectionDim-Alter.sql
@@ -1,0 +1,72 @@
+﻿-- SPDX-License-Identifier: Apache-2.0
+-- Licensed to the Ed-Fi Alliance under one or more agreements.
+-- The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+-- See the LICENSE and NOTICES files in the project root for more information.
+
+
+IF EXISTS
+(
+    SELECT 
+           1
+    FROM INFORMATION_SCHEMA.VIEWS
+    WHERE TABLE_SCHEMA = 'analytics'
+          AND TABLE_NAME = 'StudentSectionDim'
+)
+    BEGIN
+        DROP VIEW 
+             analytics.StudentSectionDim;
+END;
+GO
+CREATE VIEW analytics.StudentSectionDim
+AS
+     SELECT 
+            CAST(Student.StudentUniqueId AS NVARCHAR) + '-' + CAST(StudentSectionAssociation.SchoolId AS NVARCHAR) + '-' + StudentSectionAssociation.LocalCourseCode + '-' + CAST(StudentSectionAssociation.SchoolYear AS NVARCHAR) + '-' + StudentSectionAssociation.SectionIdentifier + '-' + StudentSectionAssociation.SessionName + '-' + CONVERT(NVARCHAR, StudentSectionAssociation.BeginDate, 112) AS StudentSectionKey, 
+            CAST(Student.StudentUniqueId AS NVARCHAR) + '-' + CAST(StudentSectionAssociation.SchoolId AS NVARCHAR) AS StudentSchoolKey,
+            Student.StudentUniqueId AS StudentKey, 
+            CAST(StudentSectionAssociation.SchoolId AS NVARCHAR) + '-' + StudentSectionAssociation.LocalCourseCode + '-' + CAST(StudentSectionAssociation.SchoolYear AS NVARCHAR) + '-' + StudentSectionAssociation.SectionIdentifier + '-' + StudentSectionAssociation.SessionName AS SectionKey, 
+            StudentSectionAssociation.LocalCourseCode, 
+            ISNULL(AcademicSubjectType.Description, '') AS Subject, 
+            ISNULL(Course.CourseTitle, '') AS CourseTitle,
+
+            -- There could be multiple teachers for a section - reduce those to a single string.
+            -- Unfortunately this means that the Staff and StaffSectionAssociation
+            -- LastModifiedDate values can't be used to calculate this record's LastModifiedDate
+            ISNULL(STUFF(
+     (
+         SELECT 
+                N', ' + ISNULL(Staff.FirstName, '') + ' ' + ISNULL(Staff.LastSurname, '')
+         FROM edfi.StaffSectionAssociation
+              LEFT OUTER JOIN edfi.Staff
+              ON StaffSectionAssociation.StaffUSI = Staff.StaffUSI
+         WHERE StudentSectionAssociation.SchoolId = StaffSectionAssociation.SchoolId
+               AND StudentSectionAssociation.LocalCourseCode = StaffSectionAssociation.LocalCourseCode
+               AND StudentSectionAssociation.SchoolYear = StaffSectionAssociation.SchoolYear
+               AND StudentSectionAssociation.SectionIdentifier = StaffSectionAssociation.SectionIdentifier
+               AND StudentSectionAssociation.SessionName = StaffSectionAssociation.SessionName FOR
+         XML PATH('')
+     ), 1, 1, N''), '') AS TeacherName, 
+            CONVERT(NVARCHAR, StudentSectionAssociation.BeginDate, 112) AS StudentSectionStartDateKey, 
+            CONVERT(NVARCHAR, StudentSectionAssociation.EndDate, 112) AS StudentSectionEndDateKey, 
+            CAST(StudentSectionAssociation.SchoolId AS VARCHAR) AS SchoolKey, 
+            CAST(StudentSectionAssociation.SchoolYear AS NVARCHAR) AS SchoolYear,
+     (
+         SELECT 
+                MAX(MaxLastModifiedDate)
+         FROM(VALUES(StudentSectionAssociation.LastModifiedDate), (Course.LastModifiedDate), (CourseOffering.LastModifiedDate), (AcademicSubjectType.LastModifiedDate)) AS VALUE(MaxLastModifiedDate)
+     ) AS LastModifiedDate
+     FROM edfi.StudentSectionAssociation
+          INNER JOIN edfi.Student
+          ON StudentSectionAssociation.StudentUSI = Student.StudentUSI
+          INNER JOIN edfi.CourseOffering
+          ON CourseOffering.SchoolId = StudentSectionAssociation.SchoolId
+             AND CourseOffering.LocalCourseCode = StudentSectionAssociation.LocalCourseCode
+             AND CourseOffering.SchoolYear = StudentSectionAssociation.SchoolYear
+             AND CourseOffering.SessionName = StudentSectionAssociation.SessionName
+          INNER JOIN edfi.Course
+          ON Course.CourseCode = CourseOffering.CourseCode
+             AND Course.EducationOrganizationId = CourseOffering.EducationOrganizationId
+          LEFT OUTER JOIN edfi.AcademicSubjectDescriptor
+          ON AcademicSubjectDescriptor.AcademicSubjectDescriptorId = Course.AcademicSubjectDescriptorId
+          LEFT OUTER JOIN edfi.Descriptor AS AcademicSubjectType
+          ON AcademicSubjectType.DescriptorId = AcademicSubjectDescriptor.AcademicSubjectDescriptorId;
+GO

--- a/src/EdFi.AnalyticsMiddleTier.DataStandard32/Base/PostgreSQL/0041-View-StudentSectionDim-Alter.sql
+++ b/src/EdFi.AnalyticsMiddleTier.DataStandard32/Base/PostgreSQL/0041-View-StudentSectionDim-Alter.sql
@@ -1,0 +1,55 @@
+﻿-- SPDX-License-Identifier: Apache-2.0
+-- Licensed to the Ed-Fi Alliance under one or more agreements.
+-- The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+-- See the LICENSE and NOTICES files in the project root for more information.
+
+DROP VIEW IF EXISTS analytics.StudentSectionDim;
+
+CREATE OR REPLACE VIEW analytics.StudentSectionDim
+AS
+    SELECT
+      CAST(Student.StudentUniqueId AS VARCHAR) || '-' || CAST(StudentSectionAssociation.SchoolId AS VARCHAR) || '-' || StudentSectionAssociation.LocalCourseCode || '-' || CAST(StudentSectionAssociation.SchoolYear AS VARCHAR) || '-' || StudentSectionAssociation.SectionIdentifier || '-' || StudentSectionAssociation.SessionName || '-' || TO_CHAR(StudentSectionAssociation.BeginDate, 'yyyymmdd') AS StudentSectionKey,
+      CAST(Student.StudentUniqueId AS VARCHAR) || '-' || CAST(StudentSectionAssociation.SchoolId AS VARCHAR) AS StudentSchoolKey,
+      Student.StudentUniqueId AS StudentKey,
+      CAST(StudentSectionAssociation.SchoolId AS VARCHAR) || '-' || StudentSectionAssociation.LocalCourseCode || '-' || CAST(StudentSectionAssociation.SchoolYear AS VARCHAR) || '-' || StudentSectionAssociation.SectionIdentifier || '-' || StudentSectionAssociation.SessionName AS SectionKey,
+      StudentSectionAssociation.LocalCourseCode,
+      COALESCE(AcademicSubjectType.Description, '') AS Subject,
+      COALESCE(Course.CourseTitle, '') AS CourseTitle,
+
+      -- There could be multiple teachers for a section - reduce those to a single string.
+      -- Unfortunately this means that the Staff and StaffSectionAssociation
+      -- LastModifiedDate values can't be used to calculate this record's LastModifiedDate
+      COALESCE((SELECT
+          STRING_AGG(COALESCE(Staff.FirstName, '') || ' ' || COALESCE(Staff.LastSurname, ''), ', ')
+        FROM edfi.StaffSectionAssociation
+          LEFT OUTER JOIN edfi.Staff
+            ON StaffSectionAssociation.StaffUSI = Staff.StaffUSI
+        WHERE StudentSectionAssociation.SchoolId = StaffSectionAssociation.SchoolId
+        AND StudentSectionAssociation.LocalCourseCode = StaffSectionAssociation.LocalCourseCode
+        AND StudentSectionAssociation.SchoolYear = StaffSectionAssociation.SchoolYear
+        AND StudentSectionAssociation.SectionIdentifier = StaffSectionAssociation.SectionIdentifier
+        AND StudentSectionAssociation.SessionName = StaffSectionAssociation.SessionName), '') AS TeacherName,
+      TO_CHAR(StudentSectionAssociation.BeginDate, 'yyyymmdd') AS StudentSectionStartDateKey,
+      TO_CHAR(StudentSectionAssociation.EndDate, 'yyyymmdd') AS StudentSectionEndDateKey,
+      CAST(StudentSectionAssociation.SchoolId AS VARCHAR) AS SchoolKey,
+      CAST(StudentSectionAssociation.SchoolYear AS VARCHAR) AS SchoolYear,
+      (SELECT
+          MAX(MaxLastModifiedDate)
+        FROM (VALUES (StudentSectionAssociation.LastModifiedDate), (Course.LastModifiedDate), (CourseOffering.LastModifiedDate), (AcademicSubjectType.LastModifiedDate))
+        AS VALUE (MaxLastModifiedDate))
+      AS LastModifiedDate
+    FROM edfi.StudentSectionAssociation
+      INNER JOIN edfi.Student
+        ON StudentSectionAssociation.StudentUSI = Student.StudentUSI
+      INNER JOIN edfi.CourseOffering
+        ON CourseOffering.SchoolId = StudentSectionAssociation.SchoolId
+        AND CourseOffering.LocalCourseCode = StudentSectionAssociation.LocalCourseCode
+        AND CourseOffering.SchoolYear = StudentSectionAssociation.SchoolYear
+        AND CourseOffering.SessionName = StudentSectionAssociation.SessionName
+      INNER JOIN edfi.Course
+        ON Course.CourseCode = CourseOffering.CourseCode
+        AND Course.EducationOrganizationId = CourseOffering.EducationOrganizationId
+      LEFT OUTER JOIN edfi.AcademicSubjectDescriptor
+        ON AcademicSubjectDescriptor.AcademicSubjectDescriptorId = Course.AcademicSubjectDescriptorId
+      LEFT OUTER JOIN edfi.Descriptor AS AcademicSubjectType
+        ON AcademicSubjectType.DescriptorId = AcademicSubjectDescriptor.AcademicSubjectDescriptorId;

--- a/src/EdFi.AnalyticsMiddleTier.Tests/Classes/StudentSectionDim.cs
+++ b/src/EdFi.AnalyticsMiddleTier.Tests/Classes/StudentSectionDim.cs
@@ -12,6 +12,7 @@ namespace EdFi.AnalyticsMiddleTier.Tests.Classes
     public class StudentSectionDim
     {
         public string StudentSectionKey { get; set; } //(nvarchar(544), null)
+        public string StudentSchoolKey { get; set; } //(nvarchar(61), null)
         public int StudentKey { get; set; } //(int, not null)
         public string SectionKey { get; set; } //(nvarchar(482), null)
         public string LocalCourseCode { get; set; } //(nvarchar(60), not null)

--- a/src/EdFi.AnalyticsMiddleTier.Tests/Dimensions/When_querying_the_StudentSectionDim_view.cs
+++ b/src/EdFi.AnalyticsMiddleTier.Tests/Dimensions/When_querying_the_StudentSectionDim_view.cs
@@ -109,6 +109,14 @@ namespace EdFi.AnalyticsMiddleTier.Tests.Dimensions.StudentSectionDimTestGroup
             }
 
             [Test]
+            public void Then_should_have_studentschoolkey()
+            {
+                Result = DataStandard.RunTestCase<StudentSectionDim>(
+                    $"{TestCasesFolder}.{DataStandard.DataStandardBaseVersion}.{_caseIdentifier}_should_have_studentschoolkey.xml");
+                Result.success.ShouldBe(true, Result.errorMessage);
+            }
+
+            [Test]
             public void Then_should_have_studentsectionenddatekey()
             {
                 Result = DataStandard.RunTestCase<StudentSectionDim>(
@@ -217,6 +225,14 @@ namespace EdFi.AnalyticsMiddleTier.Tests.Dimensions.StudentSectionDimTestGroup
             }
 
             [Test]
+            public void Then_should_have_studentschoolkey()
+            {
+                Result = DataStandard.RunTestCase<StudentSectionDim>(
+                    $"{TestCasesFolder}.{DataStandard.DataStandardBaseVersion}.{_caseIdentifier}_should_have_studentschoolkey.xml");
+                Result.success.ShouldBe(true, Result.errorMessage);
+            }
+
+            [Test]
             public void Then_should_have_studentsectionenddatekey()
             {
                 Result = DataStandard.RunTestCase<StudentSectionDim>(
@@ -321,6 +337,14 @@ namespace EdFi.AnalyticsMiddleTier.Tests.Dimensions.StudentSectionDimTestGroup
             {
                 Result = DataStandard.RunTestCase<StudentSectionDim>(
                     $"{TestCasesFolder}.{DataStandard.DataStandardBaseVersion}.{_caseIdentifier}_should_have_studentkey.xml");
+                Result.success.ShouldBe(true, Result.errorMessage);
+            }
+
+            [Test]
+            public void Then_should_have_studentschoolkey()
+            {
+                Result = DataStandard.RunTestCase<StudentSectionDim>(
+                    $"{TestCasesFolder}.{DataStandard.DataStandardBaseVersion}.{_caseIdentifier}_should_have_studentschoolkey.xml");
                 Result.success.ShouldBe(true, Result.errorMessage);
             }
 

--- a/src/EdFi.AnalyticsMiddleTier.Tests/TestCases/StudentSectionDim/MSSQL/v_2/0001_StudentSectionDim_should_match_column_dictionary.xml
+++ b/src/EdFi.AnalyticsMiddleTier.Tests/TestCases/StudentSectionDim/MSSQL/v_2/0001_StudentSectionDim_should_match_column_dictionary.xml
@@ -16,6 +16,10 @@
         <DataType>nvarchar</DataType>
     </Result>
     <Result>
+      <ColumnName>StudentSchoolKey</ColumnName>
+      <DataType>nvarchar</DataType>
+    </Result>
+    <Result>
         <ColumnName>StudentKey</ColumnName>
         <DataType>nvarchar</DataType>
     </Result>

--- a/src/EdFi.AnalyticsMiddleTier.Tests/TestCases/StudentSectionDim/MSSQL/v_3_1/0001_StudentSectionDim_should_match_column_dictionary.xml
+++ b/src/EdFi.AnalyticsMiddleTier.Tests/TestCases/StudentSectionDim/MSSQL/v_3_1/0001_StudentSectionDim_should_match_column_dictionary.xml
@@ -16,6 +16,10 @@
         <DataType>nvarchar</DataType>
     </Result>
     <Result>
+      <ColumnName>StudentSchoolKey</ColumnName>
+      <DataType>nvarchar</DataType>
+    </Result>
+    <Result>
         <ColumnName>StudentKey</ColumnName>
         <DataType>nvarchar</DataType>
     </Result>

--- a/src/EdFi.AnalyticsMiddleTier.Tests/TestCases/StudentSectionDim/PostgreSQL/v_3_2/0001_StudentSectionDim_should_match_column_dictionary.xml
+++ b/src/EdFi.AnalyticsMiddleTier.Tests/TestCases/StudentSectionDim/PostgreSQL/v_3_2/0001_StudentSectionDim_should_match_column_dictionary.xml
@@ -16,6 +16,10 @@
         <DataType>text</DataType>
     </Result>
     <Result>
+      <ColumnName>studentschoolkey</ColumnName>
+      <DataType>text</DataType>
+    </Result>
+    <Result>
         <ColumnName>studentkey</ColumnName>
         <DataType>character varying</DataType>
     </Result>

--- a/src/EdFi.AnalyticsMiddleTier.Tests/TestCases/StudentSectionDim/v_2/multiple_teachers_should_have_studentschoolkey.xml
+++ b/src/EdFi.AnalyticsMiddleTier.Tests/TestCases/StudentSectionDim/v_2/multiple_teachers_should_have_studentschoolkey.xml
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<TestCase>
+  <DBMS>Any</DBMS>
+  <ControlDataInsertion>
+  </ControlDataInsertion>
+  <Query>
+    SELECT StudentSchoolKey
+    FROM analytics.StudentSectionDim
+    WHERE StudentSectionKey = '190276-867530022-B08-CHAPMAN-CAFR41-530-2012-17128-1-20110822';
+  </Query>
+  <Result>
+    <StudentSchoolKey>190276-867530022</StudentSchoolKey>
+</Result>
+</TestCase>

--- a/src/EdFi.AnalyticsMiddleTier.Tests/TestCases/StudentSectionDim/v_2/without_subject_should_have_studentschoolkey.xml
+++ b/src/EdFi.AnalyticsMiddleTier.Tests/TestCases/StudentSectionDim/v_2/without_subject_should_have_studentschoolkey.xml
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<TestCase>
+  <DBMS>Any</DBMS>
+  <ControlDataInsertion>
+  </ControlDataInsertion>
+  <Query>
+    SELECT StudentSchoolKey
+    FROM analytics.StudentSectionDim
+    WHERE StudentSectionKey = '190276-867530022-FA01-2110-LENR41-530-2012-4575-1-20110822';
+  </Query>
+  <Result>
+    <StudentSchoolKey>190276-867530022</StudentSchoolKey>
+</Result>
+</TestCase>

--- a/src/EdFi.AnalyticsMiddleTier.Tests/TestCases/StudentSectionDim/v_2/without_teacher_should_have_studentschoolkey.xml
+++ b/src/EdFi.AnalyticsMiddleTier.Tests/TestCases/StudentSectionDim/v_2/without_teacher_should_have_studentschoolkey.xml
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<TestCase>
+  <DBMS>Any</DBMS>
+  <ControlDataInsertion>
+  </ControlDataInsertion>
+  <Query>
+    SELECT StudentSchoolKey
+    FROM analytics.StudentSectionDim
+    WHERE StudentSectionKey = '189863-867530011-T09-115-QAGR40-535-2012-18940-1-20120104';
+  </Query>
+  <Result>
+    <StudentSchoolKey>189863-867530011</StudentSchoolKey>
+</Result>
+</TestCase>

--- a/src/EdFi.AnalyticsMiddleTier.Tests/TestCases/StudentSectionDim/v_3/multiple_teachers_should_have_studentschoolkey.xml
+++ b/src/EdFi.AnalyticsMiddleTier.Tests/TestCases/StudentSectionDim/v_3/multiple_teachers_should_have_studentschoolkey.xml
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<TestCase>
+  <DBMS>Any</DBMS>
+  <ControlDataInsertion>
+  </ControlDataInsertion>
+  <Query>
+    SELECT StudentSchoolKey
+    FROM analytics.StudentSectionDim
+    WHERE StudentSectionKey = '190276-867530022-CAFR41-2012-17128-Traditional-20110822';
+  </Query>
+  <Result>
+    <StudentSchoolKey>190276-867530022</StudentSchoolKey>
+</Result>
+</TestCase>

--- a/src/EdFi.AnalyticsMiddleTier.Tests/TestCases/StudentSectionDim/v_3/without_subject_should_have_studentschoolkey.xml
+++ b/src/EdFi.AnalyticsMiddleTier.Tests/TestCases/StudentSectionDim/v_3/without_subject_should_have_studentschoolkey.xml
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<TestCase>
+  <DBMS>Any</DBMS>
+  <ControlDataInsertion>
+  </ControlDataInsertion>
+  <Query>
+    SELECT StudentSchoolKey
+    FROM analytics.StudentSectionDim
+    WHERE StudentSectionKey = '190276-867530022-LENR41-2012-4575-Traditional-20110822';
+  </Query>
+  <Result>
+    <StudentSchoolKey>190276-867530022</StudentSchoolKey>
+</Result>
+</TestCase>

--- a/src/EdFi.AnalyticsMiddleTier.Tests/TestCases/StudentSectionDim/v_3/without_teacher_should_have_studentschoolkey.xml
+++ b/src/EdFi.AnalyticsMiddleTier.Tests/TestCases/StudentSectionDim/v_3/without_teacher_should_have_studentschoolkey.xml
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<TestCase>
+  <DBMS>Any</DBMS>
+  <ControlDataInsertion>
+  </ControlDataInsertion>
+  <Query>
+    SELECT StudentSchoolKey
+    FROM analytics.StudentSectionDim
+    WHERE StudentSectionKey = '189863-867530011-QAGR40-2012-18940-Traditional-Spring Semester-20120104';
+  </Query>
+  <Result>
+    <StudentSchoolKey>189863-867530011</StudentSchoolKey>
+</Result>
+</TestCase>


### PR DESCRIPTION
This column is being added to the StudentSectionDim view to make it easier to join it to other views, such as the StudentSchoolDim. Previously joining these two views meant making a join like so:
```
SELECT *
FROM analytics.StudentSectionDim
INNER JOIN analytics.StudentSchoolDim
    ON StudentSchoolDim.SchoolKey = StudentSectionDim.SchoolKey
    AND StudentSchoolDim.StudentKey = StudentSectionDim.StudentKey
```

And instead now the join can be simpler like this:
```
SELECT *
FROM analytics.StudentSectionDim
INNER JOIN analytics.StudentSchoolDim
    ON StudentSchoolDim.StudentSchoolKey = StudentSectionDim.StudentSchoolKey

```