### PR TITLE
BIA-815 - Update documentation links around Postgres

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ The Analytics Middle Tier is a set of denormalized analytics views over the Ed-F
 For more information, see:
 
 * For a detailed description of the views, the deployment process, and how to get involved, see [Analytics Middle Tier](https://techdocs.ed-fi.org/display/EDFITOOLS/Analytics+Middle+Tier) in Tech Docs
+* For more information about how testing is done in this solution, see the [test project README](https://github.com/Ed-Fi-Alliance-OSS/Ed-Fi-Analytics-Middle-Tier/blob/main/src/EdFi.AnalyticsMiddleTier.Tests/readme.md) in this repo
 * [How to Submit an Issue](https://techdocs.ed-fi.org/display/ETKB/How+To%3A+Submit+an+Issue)
 * [How Submit a Feature Request](https://techdocs.ed-fi.org/display/ETKB/How+To%3A+Submit+a+Feature+Request)
 * Review on-going development work at [Link to appropriate Tracker project]

--- a/src/EdFi.AnalyticsMiddleTier.Tests/readme.md
+++ b/src/EdFi.AnalyticsMiddleTier.Tests/readme.md
@@ -4,16 +4,27 @@ This test package does not test the created SQL Schema in detail. It does,
 however, ensure that the migration library executes correctly. Here is how this
 project operates:
 
+## For SQL Server:
 1. Check to see if the target testing database exists on the localhost default
    database instance.
-    1. If not, then create it from the `EdFi_Ods_2.0.dacpac`. This dacpac contains
-       all of the `edfi.*` tables from the Data Standard v2.0.
-    1. Next, create a database snapshot of the target database, because restoring
-       from a snapshot is faster than dropping and recreating the database.
-1. Restore the database snapshot.
-1. Run the migration utility once.
-1. Run individual tests that confirm that each desired analytics middle tier
+    1. If not, then create it from the dacpac file for that specific Data
+       Standard. There is `EdFi_Ods_2.0.dacpac`, `EdFi_Ods_3.1.dacpac`, and
+       `EdFi_Ods_3.2.dacpac` for each Data Standard. These dacpac's contain all
+       of the `edfi.*` tables from that specific Data Standard schema.
+    2. Next, create a database snapshot of the target database, because
+       restoring from a snapshot is faster than dropping and recreating the
+       database.
+2. Restore the database snapshot.
+3. Run the migration utility once.
+4. Run individual tests that confirm that each desired analytics middle tier
    database object was created.
     1. If a SQL view has an invalid reference in it, then the deployment of that
        view will fail, and hence a single test with its assertion statement will
        fail. Thus we get schema binding validation through the testing process.
+
+## For Postgres:
+The first two steps above are not run for Postgres and instead must be manually
+done once, following steps defined [here in
+TechDocs](https://techdocs.ed-fi.org/pages/viewpage.action?pageId=98570706). The
+remaining steps are the same for running the migration utility and running the
+tests.


### PR DESCRIPTION
This updated the main readme to link to the readme inside the Test project folder and then updated the Test project readme to link to the Tech Docs page that explains the setup needed for running against Postgres.