### PR TITLE
BIA-870 - Add additional test data to show breakage in AcademicTimePeriodDim tests

### DIFF
--- a/src/EdFi.AnalyticsMiddleTier.Tests/TestCases/AcademicTimePeriodDim/PostgreSQL/v_3_2/0000_AcademicTimePeriodDim_Data_Load.xml
+++ b/src/EdFi.AnalyticsMiddleTier.Tests/TestCases/AcademicTimePeriodDim/PostgreSQL/v_3_2/0000_AcademicTimePeriodDim_Data_Load.xml
@@ -85,6 +85,9 @@
     INSERT INTO edfi.SessionGradingPeriod (GradingPeriodDescriptorId,PeriodSequence,SchoolId,SchoolYear,SessionName)
     VALUES (v_gradingDescriptorId,4,34,2012,'SchoolYear is the last modified');
 
+    INSERT INTO edfi.GradingPeriod (GradingPeriodDescriptorId,SchoolId,BeginDate,TotalInstructionalDays,EndDate,PeriodSequence,SchoolYear,LastModifiedDate)
+    VALUES (v_gradingDescriptorId,34,'1999-12-31',1,'2000-01-01',42,2012,'2003-03-03');
+
     INSERT INTO edfi.Descriptor (CodeValue,Description,ShortDescription,Namespace)
     VALUES ('Second six weeks','Second six weeks','Second six weeks','uri://ed-fi.org/GradingPeriodDescriptor')
     RETURNING descriptorid INTO v_gradingDescriptorId;


### PR DESCRIPTION
For this an additional grading period with a different Period Sequence from an existing record was added. Adding this causes the existing tests to fail when you comment out either the PeriodSequence or SchoolId in the join between SessionGradingPeriod and GradingPeriod and it also made it so that the data in edfi.GradingPeriod in Postgres and MSSQL match whereas it did not before.

Before, you can see here how in Postgres it is missing a record with a PeriodSequence of 42 and SchoolId of 34, but it exists in MSSQL:
![image](https://user-images.githubusercontent.com/1013553/137211032-15c7a988-32ed-4df1-adb0-f0c8630364b4.png)


But then after this change, that record exists in both:
![image](https://user-images.githubusercontent.com/1013553/137210593-7671d757-8abe-4698-b3f7-a3618701b557.png)
