### PR TITLE
[BIA-470] Build Script: Unit Test Command

### DIFF
--- a/src/EdFi.AnalyticsMiddleTier.Tests/Common/ExceptionExtensionsTests.cs
+++ b/src/EdFi.AnalyticsMiddleTier.Tests/Common/ExceptionExtensionsTests.cs
@@ -11,6 +11,7 @@ using System;
 namespace EdFi.AnalyticsMiddleTier.Tests.Common
 {
     [TestFixture]
+    [Category("UnitTest")]
     class ExceptionExtensionsTests
     {
         private string exceptionMessage = "Exception message";

--- a/src/EdFi.AnalyticsMiddleTier.Tests/Common/InstallBaseTest.cs
+++ b/src/EdFi.AnalyticsMiddleTier.Tests/Common/InstallBaseTest.cs
@@ -16,6 +16,7 @@ using System.Reflection;
 namespace EdFi.AnalyticsMiddleTier.Tests.Common
 {
     [SuppressMessage("ReSharper", "InconsistentNaming")]
+    [Category("UnitTest")]
     abstract class When_running_installation
     {
         protected bool Successful;

--- a/src/EdFi.AnalyticsMiddleTier.Tests/Common/When_installing_datastandard_version.cs
+++ b/src/EdFi.AnalyticsMiddleTier.Tests/Common/When_installing_datastandard_version.cs
@@ -13,6 +13,7 @@ using Shouldly;
 namespace EdFi.AnalyticsMiddleTier.Tests.Common
 {
     [SuppressMessage("ReSharper", "InconsistentNaming")]
+    [Category("UnitTest")]
     public abstract class When_installing_datastandard_version
     {
         protected IOrm Orm { get; set; }

--- a/src/EdFi.AnalyticsMiddleTier.Tests/Common/When_uninstalling_postgresql.cs
+++ b/src/EdFi.AnalyticsMiddleTier.Tests/Common/When_uninstalling_postgresql.cs
@@ -15,6 +15,7 @@ using Shouldly;
 namespace EdFi.AnalyticsMiddleTier.Tests.Common
 {
     [SuppressMessage("ReSharper", "InconsistentNaming")]
+    [Category("UnitTest")]
     public abstract class When_uninstalling_postgresql
     {
         protected IOrm Orm { get; set; }

--- a/src/EdFi.AnalyticsMiddleTier.Tests/TestCaseBase.cs
+++ b/src/EdFi.AnalyticsMiddleTier.Tests/TestCaseBase.cs
@@ -12,6 +12,7 @@ namespace EdFi.AnalyticsMiddleTier.Tests
     [SuppressMessage("ReSharper", "InconsistentNaming")]
     [NonParallelizable]
     [TestFixtureSource(typeof(DataStandardTestFixture))]
+    [Category("IntegrationTest")]
     public abstract class TestCaseBase
     {
         protected TestHarnessBase DataStandard { get; set; }


### PR DESCRIPTION
Categories are added to test classes.
The script is modified to add the UnitTest option.

Steps

1. Build the project.

`.\build.ps1 build`

2. Run the unit tests.
`.\build.ps1 unittest`