### PR TITLE
[BIA-472] - Build Script: Publish Self-Contained and Framework-Dependent Deployments

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -56,7 +56,7 @@ $Env:MSBUILDDISABLENODEREUSE = "1"
 $solutionRoot = "$PSScriptRoot/src"
 $maintainers = "Ed-Fi Alliance, LLC and contributors"
 	Import-Module -Name "$PSScriptRoot/eng/build-helpers.psm1" -Force
-$publishOutputPath = "$solutionRoot/Ed-Fi-Analytics-Middle-Tier/publish/"
+$publishOutputPath = "$solutionRoot/../publish/"
 
 function Clean {
     Invoke-Execute { dotnet clean $solutionRoot -c $Configuration --nologo -v minimal }

--- a/src/EdFi.AnalyticsMiddleTier.Console/EdFi.AnalyticsMiddleTier.Console.csproj
+++ b/src/EdFi.AnalyticsMiddleTier.Console/EdFi.AnalyticsMiddleTier.Console.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
+    <!-- <RuntimeIdentifier>win10-x64</RuntimeIdentifier> -->
     <Authors>Ed-Fi Alliance</Authors>
     <Company>Ed-Fi Alliance</Company>
     <Copyright>Copyright (c) 2018, Ed-Fi Alliance</Copyright>

--- a/src/EdFi.AnalyticsMiddleTier.Console/EdFi.AnalyticsMiddleTier.Console.csproj
+++ b/src/EdFi.AnalyticsMiddleTier.Console/EdFi.AnalyticsMiddleTier.Console.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <!-- <RuntimeIdentifier>win10-x64</RuntimeIdentifier> -->
+    <RuntimeIdentifier>win10-x64</RuntimeIdentifier>
     <Authors>Ed-Fi Alliance</Authors>
     <Company>Ed-Fi Alliance</Company>
     <Copyright>Copyright (c) 2018, Ed-Fi Alliance</Copyright>


### PR DESCRIPTION
### Changes: 

1. The `Build` command changed. It now just builds and doesn't publish. 

2. A new command has been added: `Publish`. By default it publishes with the no-self-contained flag

2.1. To publish a self contained deployment, the call looks something like:
`.\build.ps1 Publish -SelfContained -Configuration debug -Version "1" -BuildCounter 1`

2.2. To publish a NO self contained deployment, the call looks something like:
`.\build.ps1 Publish -Configuration debug -Version "1" -BuildCounter 1`

The difference is the inclusion or not of the `-SelfContained` flag.

### How to test this

When you publish, the script creates a new folder here with the deployment:
`\src\Ed-Fi-Analytics-Middle-Tier\publish\`
Based on whether or not you included the `-SelfContained` flag, the content of the published folder changes:

**SelfContained**: 70.2 Mb aprox.
**NoSelftContained**: 4.13 Mb aprox.

### More info:
These changes include part of the BIA-473 as well. It would be pending on that ticket, to change the step in TeamCity, but the script changes are here as well. 
