### PR TITLE
[BIA-478] GitHub Actions: Packaging

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ on:
   workflow_dispatch:
 
 env:
-  BUILD_VERSION: "2.6.1"
+  BUILD_VERSION: ${{ secrets.SEMANTIC_VERSION }}
   CONFIGURATION: "Release"
   GA_USE_GITHUB_ENV: "true"
   USE_MSSQL_DEFAULT_CONN_STRING: "FALSE"

--- a/.github/workflows/create-pre-release.yml
+++ b/.github/workflows/create-pre-release.yml
@@ -3,9 +3,23 @@
 # The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 # See the LICENSE and NOTICES files in the project root for more information.
 
-name: Create Pre-Release
+name: Create Release/Pre-Release
 
-on: workflow_dispatch
+on: 
+  workflow_dispatch:
+    inputs:
+      releaseName:
+        description: 'Release Name'     
+        required: true
+        default: '<AMT>'
+      releaseDescription:
+        description: 'Release Description'     
+        required: true
+        default: '<Description>'
+      createRelease:
+        description: 'Create Release'     
+        required: true
+        default: 'false'
 
 env:
   BUILD_VERSION:  ${{ secrets.SEMANTIC_VERSION }}
@@ -50,13 +64,14 @@ jobs:
         uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+          RELEASE_TAG:  ${{ contains( github.event.inputs.createRelease, 'true') && env.BUILD_VERSION ||  format('{0}-pr-{1}', env.BUILD_VERSION, github.run_id)  }}
         with:
-          tag_name: ${{ env.BUILD_VERSION }}-pre${{ github.run_id }}
-          release_name: ${{ env.BUILD_VERSION }} <Release name> 
+          tag_name: ${{ env.RELEASE_TAG }}
+          release_name: ${{ env.BUILD_VERSION }}  ${{ github.event.inputs.releaseName }}
           body: |
-            <Release description>
+            ${{ github.event.inputs.releaseDescription }}
           draft: false
-          prerelease: true
+          prerelease: ${{ !contains( github.event.inputs.createRelease, 'true') }}
 
       - name: Upload publish zip
         id: upload-publish-zip-asset 

--- a/.github/workflows/create-pre-release.yml
+++ b/.github/workflows/create-pre-release.yml
@@ -64,7 +64,7 @@ jobs:
         uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
-          RELEASE_TAG:  ${{ contains( github.event.inputs.createRelease, 'true') && env.BUILD_VERSION ||  format('{0}-pr-{1}', env.BUILD_VERSION, github.run_id)  }}
+          RELEASE_TAG:  ${{ contains( github.event.inputs.createRelease, 'true') && env.BUILD_VERSION ||  format('{0}-pre-{1}', env.BUILD_VERSION, github.run_id)  }}
         with:
           tag_name: ${{ env.RELEASE_TAG }}
           release_name: ${{ env.BUILD_VERSION }}  ${{ github.event.inputs.releaseName }}

--- a/.github/workflows/create-pre-release.yml
+++ b/.github/workflows/create-pre-release.yml
@@ -1,0 +1,81 @@
+# SPDX-License-Identifier: Apache-2.0
+# Licensed to the Ed-Fi Alliance under one or more agreements.
+# The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+# See the LICENSE and NOTICES files in the project root for more information.
+
+name: Create Pre-Release
+
+on: workflow_dispatch
+
+env:
+  BUILD_VERSION:  ${{ secrets.SEMANTIC_VERSION }}
+  CONFIGURATION: "Release"
+  PUBLISH_FOLDER: "./publish/"
+  PUBLISH_FDD_ZIP: "EdFi.AnalyticsMiddleTier.zip"
+  PUBLISH_SCD_ZIP: "EdFi.AnalyticsMiddleTier-win10.x64.zip"
+
+jobs:
+  AMT-Create-Release:
+    runs-on: Ubuntu-latest
+   
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      
+      - name: Caching packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/packages.lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-nuget-
+   
+      - name: Publish self-contained deployment
+        run: |
+          .\build.ps1 publish -SelfContained ${{ env.CONFIGURATION }} -Version ${{ env.BUILD_VERSION }} -BuildCounter ${{ github.run_number }}
+        shell: pwsh
+
+      - name: Publish framework-dependent deployment
+        run: |
+          .\build.ps1 publish -Configuration ${{ env.CONFIGURATION }} -Version ${{ env.BUILD_VERSION }} -BuildCounter ${{ github.run_number }}
+        shell: pwsh
+
+      - name: Create Zip file
+        run: |
+          .\build.ps1 CreateZip -Configuration ${{ env.CONFIGURATION }} -Version ${{ env.BUILD_VERSION }} -BuildCounter ${{ github.run_number }}
+        shell: pwsh
+
+      - name: Create pre-release
+        id: create_pre_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+        with:
+          tag_name: ${{ env.BUILD_VERSION }}-pre${{ github.run_id }}
+          release_name: ${{ env.BUILD_VERSION }} <Release name> 
+          body: |
+            <Release description>
+          draft: false
+          prerelease: true
+
+      - name: Upload publish zip
+        id: upload-publish-zip-asset 
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_pre_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
+          asset_path: ${{ env.PUBLISH_FOLDER }}${{ env.PUBLISH_FDD_ZIP }}
+          asset_name: ${{ env.PUBLISH_FDD_ZIP }}
+          asset_content_type: application/zip
+
+      - name: Upload self-contained publish zip
+        id: upload-publish-self-contained-zip-asset 
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_pre_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
+          asset_path: ${{ env.PUBLISH_FOLDER }}${{ env.PUBLISH_SCD_ZIP }}
+          asset_name: ${{ env.PUBLISH_SCD_ZIP }}
+          asset_content_type: application/zip


### PR DESCRIPTION
- Add github actions workflow to create a pre-release.
- Add a new secret SEMANTIC_VERSION to share the version between build and create-pre-release workflows.

Select Actions: Create Release/Pre-release.
Parameter:

- Name.
- Description.
- Release: true -> Create Release. Other value: Create pre-release

![image](https://user-images.githubusercontent.com/56046999/144324819-a83b83aa-baad-4168-8fb5-827930b84ba9.png)
