### PR TITLE
[BIA-884] Support building AMT on Linux

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -125,19 +125,6 @@ function Compile {
     Invoke-Execute {
         dotnet --info
         dotnet build $solutionRoot -c $Configuration --nologo
-
-        # Copy .env file if it exists
-        #if (Test-Path -Path $solutionRoot/$testProjectName/.env -PathType leaf) {
-        #    $doc = New-Object System.Xml.XmlDocument
-        #    $projectFile = Get-Item $solutionRoot/$testProjectName/$testProjectName'.csproj'
-        #    $doc.Load($projectFile)
-        #    $TargetFrameworkNode = $doc.SelectSingleNode("Project//PropertyGroup//TargetFramework")
-
-        #    if ($TargetFrameworkNode) {
-        #        $TargetFramework = $TargetFrameworkNode.InnerText
-        #        Copy-Item $solutionRoot/$testProjectName/.env -Destination $solutionRoot/$testProjectName/bin/$Configuration/$TargetFramework/ -Force
-        #    }
-        #}
     }
 }
 

--- a/build.ps1
+++ b/build.ps1
@@ -127,17 +127,17 @@ function Compile {
         dotnet build $solutionRoot -c $Configuration --nologo
 
         # Copy .env file if it exists
-        if (Test-Path -Path $solutionRoot/$testProjectName/.env -PathType leaf) {
-            $doc = New-Object System.Xml.XmlDocument
-            $projectFile = Get-Item $solutionRoot/$testProjectName/$testProjectName'.csproj'
-            $doc.Load($projectFile)
-            $TargetFrameworkNode = $doc.SelectSingleNode("Project//PropertyGroup//TargetFramework")
+        #if (Test-Path -Path $solutionRoot/$testProjectName/.env -PathType leaf) {
+        #    $doc = New-Object System.Xml.XmlDocument
+        #    $projectFile = Get-Item $solutionRoot/$testProjectName/$testProjectName'.csproj'
+        #    $doc.Load($projectFile)
+        #    $TargetFrameworkNode = $doc.SelectSingleNode("Project//PropertyGroup//TargetFramework")
 
-            if ($TargetFrameworkNode) {
-                $TargetFramework = $TargetFrameworkNode.InnerText
-                Copy-Item $solutionRoot/$testProjectName/.env -Destination $solutionRoot/$testProjectName/bin/$Configuration/$TargetFramework/ -Force
-            }
-        }
+        #    if ($TargetFrameworkNode) {
+        #        $TargetFramework = $TargetFrameworkNode.InnerText
+        #        Copy-Item $solutionRoot/$testProjectName/.env -Destination $solutionRoot/$testProjectName/bin/$Configuration/$TargetFramework/ -Force
+        #    }
+        #}
     }
 }
 

--- a/src/EdFi.AnalyticsMiddleTier.Tests/EdFi.AnalyticsMiddleTier.Tests.csproj
+++ b/src/EdFi.AnalyticsMiddleTier.Tests/EdFi.AnalyticsMiddleTier.Tests.csproj
@@ -63,10 +63,8 @@
     <None Update="EdFi_Ods_3.3.dacpac">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+	<None Include=".env" Condition="Exists('.env')">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
-
-  <Target Name="PostBuild" AfterTargets="PostBuildEvent" Condition="'$(BuildingInsideVisualStudio)' == 'true'">
-    <Exec Command="IF EXIST .env del $(OutputPath)\.env&#xD;&#xA;IF EXIST .env xcopy .env $(OutputPath)\ /Y" />
-  </Target>
-
 </Project>


### PR DESCRIPTION
Update test csproj to copy, if exists, the .env file to the output folder.

To test:
- Test build.ps1 and VS build and don't include and .env file. It must work.
- Add the .env file to the test project.
- Run .\build.ps1. It will copy the file to the output folder.
- Run build option using Visual Studio. The .env must be copy to the output folder.