### PR TITLE
[BIA-1014] Adds Epp collection to the AMT installer.

### DIFF
--- a/src/EdFi.AnalyticsMiddleTier.Console/Program.cs
+++ b/src/EdFi.AnalyticsMiddleTier.Console/Program.cs
@@ -137,7 +137,10 @@ namespace EdFi.AnalyticsMiddleTier.Console
                         message += NotSupportedOnDs2(dataStandardVersion, options, Component.Asmt);
                         message += NotSupportedOnDs2(dataStandardVersion, options, Component.Equity);
                         message += NotSupportedOnDs2(dataStandardVersion, options, Component.Engage);
+                        message += NotSupportedOnDs2(dataStandardVersion, options, Component.EPP);
                         message += NotSupportedOnDs31(dataStandardVersion, options, Component.Engage);
+                        message += NotSupportedOnDs31(dataStandardVersion, options, Component.EPP);
+                        message += NotSupportedOnDs32(dataStandardVersion, options, Component.EPP);
                         message += NotSupportedOnPostgres(options, Component.Engage);
                         
                         if (string.IsNullOrEmpty(message))
@@ -197,6 +200,16 @@ namespace EdFi.AnalyticsMiddleTier.Console
                 if (dataStandardVersion == DataStandard.Ds31 && options.Components.Contains(collection))
                 {
                     return $"The {collection} collection is not supported on Data Standard 3.1. Please remove this option and try again.";
+                }
+
+                return null;
+            }
+
+            static string NotSupportedOnDs32(DataStandard dataStandardVersion, Options options, Component collection)
+            {
+                if (dataStandardVersion == DataStandard.Ds32 && options.Components.Contains(collection))
+                {
+                    return $"The {collection} collection is not supported on Data Standard 3.2. Please remove this option and try again.";
                 }
 
                 return null;

--- a/src/EdFi.AnalyticsMiddleTier.Tests/Operation/When_installing_Epp_views.cs
+++ b/src/EdFi.AnalyticsMiddleTier.Tests/Operation/When_installing_Epp_views.cs
@@ -1,0 +1,57 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Diagnostics.CodeAnalysis;
+using EdFi.AnalyticsMiddleTier.Common;
+using NUnit.Framework;
+using Shouldly;
+using CommonLib = EdFi.AnalyticsMiddleTier.Common;
+
+// ReSharper disable once CheckNamespace
+namespace EdFi.AnalyticsMiddleTier.Tests.Operation
+{
+    [SuppressMessage("ReSharper", "InconsistentNaming")]
+    public class When_installing_Epp_views : When_installing_a_Collection
+    {
+        public When_installing_Epp_views(TestHarnessBase dataStandard) => SetDataStandard(dataStandard);
+
+        [OneTimeSetUp]
+        public void Act()
+        {
+            if (DataStandard.DataStandardVersion.Equals(CommonLib.DataStandard.Ds2)
+                || DataStandard.DataStandardVersion.Equals(CommonLib.DataStandard.Ds31)
+                || DataStandard.DataStandardVersion.Equals(CommonLib.DataStandard.Ds32))
+            {
+                Assert.Ignore($"The collection Epp does not exist in this version of the Data Standard. ({DataStandard.DataStandardVersion.ToString()})");
+            }
+            else
+            {
+                Result = DataStandard.Install(10, Component.EPP);
+            }
+        }
+
+        [OneTimeTearDown]
+        public void Uninstall()
+        {
+            Result = DataStandard.Uninstall();
+        }
+
+        [Test]
+        public void Then_result_success_should_be_true() => Result.success.ShouldBe(true);
+
+        [Test]
+        public void Then_error_message_should_be_null_or_empty() => Result.errorMessage.ShouldBeNullOrEmpty();
+
+        [TestCase("EPP_CandidateDim")]
+        [TestCase("epp_CandidateSurveyDim")]
+        [TestCase("EPP_EvaluationElementRatingDim")]
+        [TestCase("epp_TermDescriptorDim")]
+        [TestCase("EPP_EppDim")]
+        [TestCase("EPP_FinancialAidFact")]
+        public void Then_should_create_analytics_epp_views(string viewName) =>
+            DataStandard.ViewExists(viewName).ShouldBe(true);
+
+    }
+}


### PR DESCRIPTION
### To test this:
1. Make sure you can **install** AMT Data Standard 3.3 with EPP collection on MSSQL and Postgres.
2. Make sure you can **uninstall** and then **reinstall** AMT Data Standard 3.3 with EPP collection on MSSQL and Postgres.
3. Make sure you can't install EPP collection on any other Data Standard. And you get a nice error message.
4. Make sure we covered all the necessary Operations tests and all run successfully. 