### PR TITLE
[BIA-1331] Update indicators to add spaces between word (DS 3.3, 4.0)

### DIFF
--- a/src/EdFi.AnalyticsMiddleTier.DataStandard33/Base/MSSQL/0040-View-StudentLocalEducationAgencyDim-Alter.sql
+++ b/src/EdFi.AnalyticsMiddleTier.DataStandard33/Base/MSSQL/0040-View-StudentLocalEducationAgencyDim-Alter.sql
@@ -3,6 +3,12 @@
 -- The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 -- See the LICENSE and NOTICES files in the project root for more information.
 
+IF EXISTS (SELECT 1 FROM INFORMATION_SCHEMA.VIEWS WHERE TABLE_SCHEMA = 'analytics' AND TABLE_NAME = 'StudentLocalEducationAgencyDim')
+BEGIN
+    DROP VIEW analytics.StudentLocalEducationAgencyDim
+END
+GO
+
 CREATE VIEW analytics.StudentLocalEducationAgencyDim
 AS
     SELECT 

--- a/src/EdFi.AnalyticsMiddleTier.DataStandard33/Base/PostgreSQL/0039-View-StudentLocalEducationAgencyDim-Alter.sql
+++ b/src/EdFi.AnalyticsMiddleTier.DataStandard33/Base/PostgreSQL/0039-View-StudentLocalEducationAgencyDim-Alter.sql
@@ -2,18 +2,19 @@
 -- Licensed to the Ed-Fi Alliance under one or more agreements.
 -- The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 -- See the LICENSE and NOTICES files in the project root for more information.
+DROP VIEW IF EXISTS analytics.StudentLocalEducationAgencyDim;
 
-CREATE VIEW analytics.StudentLocalEducationAgencyDim
+CREATE OR REPLACE VIEW analytics.StudentLocalEducationAgencyDim
 AS
-    SELECT 
+   SELECT 
            CONCAT(Student.StudentUniqueId, '-', LocalEducationAgency.LocalEducationAgencyId) AS StudentLocalEducationAgencyKey,
-           Student.StudentUniqueId ​AS StudentKey​,
+           Student.StudentUniqueId AS StudentKey,
            CAST(LocalEducationAgency.LocalEducationAgencyId AS VARCHAR) AS LocalEducationAgencyKey, 
            Student.FirstName AS StudentFirstName, 
            COALESCE(Student.MiddleName, '') AS StudentMiddleName, 
            Student.LastSurname AS StudentLastName, 
            COALESCE(LimitedEnglishProficiencyDescriptor.CodeValue, 'Not Applicable') AS LimitedEnglishProficiency, 
-           CAST(COALESCE(StudentEducationOrganizationAssociation.HispanicLatinoEthnicity, 0) as BIT) AS IsHispanic, 
+           COALESCE(StudentEducationOrganizationAssociation.HispanicLatinoEthnicity, false) AS IsHispanic, 
            COALESCE(SexDescriptor.CodeValue, '') AS Sex,
            COALESCE(InternetAccessInResidence.Indicator,'n/a') as InternetAccessInResidence,
            COALESCE(InternetAccessTypeInResidence.Indicator,'n/a') as InternetAccessTypeInResidence,
@@ -69,7 +70,7 @@ AS
             AND
             StudentEducationOrganizationAssociation.EducationOrganizationId = DigitalDevice.EducationOrganizationId
             AND
-           DigitalDevice.IndicatorName = 'Digital Device'
+            DigitalDevice.IndicatorName = 'Digital Device'
     LEFT OUTER JOIN
         edfi.StudentEducationOrganizationAssociationStudentIndicator AS DeviceAccess ON
             StudentEducationOrganizationAssociation.StudentUSI = DeviceAccess.StudentUSI
@@ -77,5 +78,5 @@ AS
             StudentEducationOrganizationAssociation.EducationOrganizationId = DeviceAccess.EducationOrganizationId
             AND
             DeviceAccess.IndicatorName = 'Device Access'
-    WHERE
-        StudentSchoolAssociation.ExitWithdrawDate IS NULL OR StudentSchoolAssociation.ExitWithdrawDate > GETDATE();    
+   WHERE
+        StudentSchoolAssociation.ExitWithdrawDate IS NULL OR StudentSchoolAssociation.ExitWithdrawDate > NOW();

--- a/src/EdFi.AnalyticsMiddleTier.DataStandard40/Base/PostgreSQL/0018-View-StudentLocalEducationAgencyDim-Create.sql
+++ b/src/EdFi.AnalyticsMiddleTier.DataStandard40/Base/PostgreSQL/0018-View-StudentLocalEducationAgencyDim-Create.sql
@@ -69,13 +69,13 @@ AS
             AND
             StudentEducationOrganizationAssociation.EducationOrganizationId = DigitalDevice.EducationOrganizationId
             AND
-            DigitalDevice.IndicatorName = 'DigitalDevice'
+            DigitalDevice.IndicatorName = 'Digital Device'
     LEFT OUTER JOIN
         edfi.StudentEducationOrganizationAssociationStudentIndicator AS DeviceAccess ON
             StudentEducationOrganizationAssociation.StudentUSI = DeviceAccess.StudentUSI
             AND
             StudentEducationOrganizationAssociation.EducationOrganizationId = DeviceAccess.EducationOrganizationId
             AND
-            DeviceAccess.IndicatorName = 'DeviceAccess'
+            DeviceAccess.IndicatorName = 'Device Access'
    WHERE
         StudentSchoolAssociation.ExitWithdrawDate IS NULL OR StudentSchoolAssociation.ExitWithdrawDate > NOW();

--- a/src/EdFi.AnalyticsMiddleTier.DataStandard40/Base/PostgreSQL/0018-View-StudentLocalEducationAgencyDim-Create.sql
+++ b/src/EdFi.AnalyticsMiddleTier.DataStandard40/Base/PostgreSQL/0018-View-StudentLocalEducationAgencyDim-Create.sql
@@ -48,21 +48,21 @@ AS
             AND
             StudentEducationOrganizationAssociation.EducationOrganizationId = InternetAccessInResidence.EducationOrganizationId
             AND
-            InternetAccessInResidence.IndicatorName = 'InternetAccessInResidence'
+            InternetAccessInResidence.IndicatorName = 'Internet Access In Residence'
     LEFT OUTER JOIN
         edfi.StudentEducationOrganizationAssociationStudentIndicator AS InternetAccessTypeInResidence ON
             StudentEducationOrganizationAssociation.StudentUSI = InternetAccessTypeInResidence.StudentUSI
             AND
             StudentEducationOrganizationAssociation.EducationOrganizationId = InternetAccessTypeInResidence.EducationOrganizationId
             AND
-            InternetAccessTypeInResidence.IndicatorName = 'InternetAccessTypeInResidence'
+            InternetAccessTypeInResidence.IndicatorName = 'Internet Access Type In Residence'
     LEFT OUTER JOIN
         edfi.StudentEducationOrganizationAssociationStudentIndicator AS InternetPerformance ON
             StudentEducationOrganizationAssociation.StudentUSI = InternetPerformance.StudentUSI
             AND
             StudentEducationOrganizationAssociation.EducationOrganizationId = InternetPerformance.EducationOrganizationId
             AND
-            InternetPerformance.IndicatorName = 'InternetPerformance'
+            InternetPerformance.IndicatorName = 'Internet Performance'
     LEFT OUTER JOIN
         edfi.StudentEducationOrganizationAssociationStudentIndicator AS DigitalDevice ON
             StudentEducationOrganizationAssociation.StudentUSI = DigitalDevice.StudentUSI

--- a/src/EdFi.AnalyticsMiddleTier.Tests/DataStandardConfiguration/DataStandardTestFixtureBase.cs
+++ b/src/EdFi.AnalyticsMiddleTier.Tests/DataStandardConfiguration/DataStandardTestFixtureBase.cs
@@ -28,7 +28,7 @@ namespace EdFi.AnalyticsMiddleTier.Tests.DataStandardConfiguration
     {
         public DataStandardTestFixture()
         {
-            FixtureList = new ITestHarnessBase[] { TestHarnessSQLServer.DataStandard2, TestHarnessSQLServer.DataStandard31, TestHarnessSQLServer.DataStandard32, TestHarnessSQLServer.DataStandard33/*, TestHarnessSQLServer.DataStandard40*/ };
+            FixtureList = new ITestHarnessBase[] { TestHarnessSQLServer.DataStandard2, TestHarnessSQLServer.DataStandard31, TestHarnessSQLServer.DataStandard32, TestHarnessSQLServer.DataStandard33, TestHarnessSQLServer.DataStandard40 };
         }
     }
 
@@ -36,7 +36,7 @@ namespace EdFi.AnalyticsMiddleTier.Tests.DataStandardConfiguration
     {
         public DataStandardTestFixtureDs3()
         {
-            FixtureList = new ITestHarnessBase[] { TestHarnessSQLServer.DataStandard31, TestHarnessSQLServer.DataStandard32, TestHarnessSQLServer.DataStandard33/*, TestHarnessSQLServer.DataStandard40 */};
+            FixtureList = new ITestHarnessBase[] { TestHarnessSQLServer.DataStandard31, TestHarnessSQLServer.DataStandard32, TestHarnessSQLServer.DataStandard33, TestHarnessSQLServer.DataStandard40};
         }
     }
 
@@ -45,8 +45,8 @@ namespace EdFi.AnalyticsMiddleTier.Tests.DataStandardConfiguration
         public DataStandardTestFixtureDs3_3_and_4_0()
         {
             FixtureList = new ITestHarnessBase[] { 
-                TestHarnessSQLServer.DataStandard33, //TestHarnessSQLServer.DataStandard40, 
-                TestHarnessPostgres.DataStandard33PG//, TestHarnessPostgres.DataStandard40PG
+                TestHarnessSQLServer.DataStandard33, TestHarnessSQLServer.DataStandard40, 
+                TestHarnessPostgres.DataStandard33PG, TestHarnessPostgres.DataStandard40PG
             };
         }
     }
@@ -56,8 +56,8 @@ namespace EdFi.AnalyticsMiddleTier.Tests.DataStandardConfiguration
         public DataStandardTestFixturePostgres()
         {
             FixtureList = new ITestHarnessBase[] { 
-                TestHarnessSQLServer.DataStandard2, TestHarnessSQLServer.DataStandard31, TestHarnessSQLServer.DataStandard32, TestHarnessSQLServer.DataStandard33,// TestHarnessSQLServer.DataStandard40,
-                TestHarnessPostgres.DataStandard32PG, TestHarnessPostgres.DataStandard33PG/*, TestHarnessPostgres.DataStandard40PG*/ };
+                TestHarnessSQLServer.DataStandard2, TestHarnessSQLServer.DataStandard31, TestHarnessSQLServer.DataStandard32, TestHarnessSQLServer.DataStandard33, TestHarnessSQLServer.DataStandard40,
+                TestHarnessPostgres.DataStandard32PG, TestHarnessPostgres.DataStandard33PG, TestHarnessPostgres.DataStandard40PG };
         }
     }
 
@@ -66,8 +66,8 @@ namespace EdFi.AnalyticsMiddleTier.Tests.DataStandardConfiguration
         public DataStandardTestFixturePostgresDs3()
         {
             FixtureList = new ITestHarnessBase[] { 
-                TestHarnessSQLServer.DataStandard31, TestHarnessSQLServer.DataStandard32, TestHarnessSQLServer.DataStandard33, //TestHarnessSQLServer.DataStandard40,
-                TestHarnessPostgres.DataStandard32PG, TestHarnessPostgres.DataStandard33PG/*, TestHarnessPostgres.DataStandard40PG*/ };
+                TestHarnessSQLServer.DataStandard31, TestHarnessSQLServer.DataStandard32, TestHarnessSQLServer.DataStandard33, TestHarnessSQLServer.DataStandard40,
+                TestHarnessPostgres.DataStandard32PG, TestHarnessPostgres.DataStandard33PG, TestHarnessPostgres.DataStandard40PG };
         }
     }
 }

--- a/src/EdFi.AnalyticsMiddleTier.Tests/DataStandardConfiguration/DataStandardTestFixtureBase.cs
+++ b/src/EdFi.AnalyticsMiddleTier.Tests/DataStandardConfiguration/DataStandardTestFixtureBase.cs
@@ -28,7 +28,7 @@ namespace EdFi.AnalyticsMiddleTier.Tests.DataStandardConfiguration
     {
         public DataStandardTestFixture()
         {
-            FixtureList = new ITestHarnessBase[] { TestHarnessSQLServer.DataStandard2, TestHarnessSQLServer.DataStandard31, TestHarnessSQLServer.DataStandard32, TestHarnessSQLServer.DataStandard33, TestHarnessSQLServer.DataStandard40 };
+            FixtureList = new ITestHarnessBase[] { TestHarnessSQLServer.DataStandard2, TestHarnessSQLServer.DataStandard31, TestHarnessSQLServer.DataStandard32, TestHarnessSQLServer.DataStandard33/*, TestHarnessSQLServer.DataStandard40*/ };
         }
     }
 
@@ -36,7 +36,7 @@ namespace EdFi.AnalyticsMiddleTier.Tests.DataStandardConfiguration
     {
         public DataStandardTestFixtureDs3()
         {
-            FixtureList = new ITestHarnessBase[] { TestHarnessSQLServer.DataStandard31, TestHarnessSQLServer.DataStandard32, TestHarnessSQLServer.DataStandard33, TestHarnessSQLServer.DataStandard40 };
+            FixtureList = new ITestHarnessBase[] { TestHarnessSQLServer.DataStandard31, TestHarnessSQLServer.DataStandard32, TestHarnessSQLServer.DataStandard33/*, TestHarnessSQLServer.DataStandard40 */};
         }
     }
 
@@ -45,8 +45,8 @@ namespace EdFi.AnalyticsMiddleTier.Tests.DataStandardConfiguration
         public DataStandardTestFixtureDs3_3_and_4_0()
         {
             FixtureList = new ITestHarnessBase[] { 
-                TestHarnessSQLServer.DataStandard33, TestHarnessSQLServer.DataStandard40, 
-                TestHarnessPostgres.DataStandard33PG, TestHarnessPostgres.DataStandard40PG
+                TestHarnessSQLServer.DataStandard33, //TestHarnessSQLServer.DataStandard40, 
+                TestHarnessPostgres.DataStandard33PG//, TestHarnessPostgres.DataStandard40PG
             };
         }
     }
@@ -56,8 +56,8 @@ namespace EdFi.AnalyticsMiddleTier.Tests.DataStandardConfiguration
         public DataStandardTestFixturePostgres()
         {
             FixtureList = new ITestHarnessBase[] { 
-                TestHarnessSQLServer.DataStandard2, TestHarnessSQLServer.DataStandard31, TestHarnessSQLServer.DataStandard32, TestHarnessSQLServer.DataStandard33, TestHarnessSQLServer.DataStandard40,
-                TestHarnessPostgres.DataStandard32PG, TestHarnessPostgres.DataStandard33PG, TestHarnessPostgres.DataStandard40PG };
+                TestHarnessSQLServer.DataStandard2, TestHarnessSQLServer.DataStandard31, TestHarnessSQLServer.DataStandard32, TestHarnessSQLServer.DataStandard33,// TestHarnessSQLServer.DataStandard40,
+                TestHarnessPostgres.DataStandard32PG, TestHarnessPostgres.DataStandard33PG/*, TestHarnessPostgres.DataStandard40PG*/ };
         }
     }
 
@@ -66,8 +66,8 @@ namespace EdFi.AnalyticsMiddleTier.Tests.DataStandardConfiguration
         public DataStandardTestFixturePostgresDs3()
         {
             FixtureList = new ITestHarnessBase[] { 
-                TestHarnessSQLServer.DataStandard31, TestHarnessSQLServer.DataStandard32, TestHarnessSQLServer.DataStandard33, TestHarnessSQLServer.DataStandard40,
-                TestHarnessPostgres.DataStandard32PG, TestHarnessPostgres.DataStandard33PG, TestHarnessPostgres.DataStandard40PG };
+                TestHarnessSQLServer.DataStandard31, TestHarnessSQLServer.DataStandard32, TestHarnessSQLServer.DataStandard33, //TestHarnessSQLServer.DataStandard40,
+                TestHarnessPostgres.DataStandard32PG, TestHarnessPostgres.DataStandard33PG/*, TestHarnessPostgres.DataStandard40PG*/ };
         }
     }
 }

--- a/src/EdFi.AnalyticsMiddleTier.Tests/TestCases/StudentLocalEducationAgencyDim/MSSQL/v_3_3/0000_StudentLocalEducationAgencyDim_Data_Load.xml
+++ b/src/EdFi.AnalyticsMiddleTier.Tests/TestCases/StudentLocalEducationAgencyDim/MSSQL/v_3_3/0000_StudentLocalEducationAgencyDim_Data_Load.xml
@@ -167,22 +167,22 @@
         (EducationOrganizationId,StudentUSI,IndicatorName,Indicator)
         VALUES
         -- @studentUsi1 happy path
-        (@districtId,@studentUsi1,'InternetAccessInResidence','Yes'),
-        (@districtId,@studentUsi1,'InternetAccessTypeInResidence','ResidentialBroadband'),
-        (@districtId,@studentUsi1,'InternetPerformance','Yes - No issues'),
-        (@districtId,@studentUsi1,'DigitalDevice','Chromebook'),
-        (@districtId,@studentUsi1,'DeviceAccess','School Provided - Dedicated'),
+        (@districtId,@studentUsi1,'Internet Access In Residence','Yes'),
+        (@districtId,@studentUsi1,'Internet Access Type In Residence','ResidentialBroadband'),
+        (@districtId,@studentUsi1,'Internet Performance','Yes - No issues'),
+        (@districtId,@studentUsi1,'Digital Device','Chromebook'),
+        (@districtId,@studentUsi1,'Device Access','School Provided - Dedicated'),
 
         -- These extra records should be ignored by the view because
         -- they are associated with the School, not the District
-        (@schoolId1,@studentUsi1,'InternetAccessInResidence','Yes__'),
-        (@schoolId1,@studentUsi1,'InternetAccessTypeInResidence','ResidentialBroadband__'),
-        (@schoolId1,@studentUsi1,'InternetPerformance','Yes - No issues__'),
-        (@schoolId1,@studentUsi1,'DigitalDevice','Chromebook__'),
-        (@schoolId1,@studentUsi1,'DeviceAccess','School Provided - Dedicated__'),
+        (@schoolId1,@studentUsi1,'Internet Access In Residence','Yes__'),
+        (@schoolId1,@studentUsi1,'Internet Access Type In Residence','ResidentialBroadband__'),
+        (@schoolId1,@studentUsi1,'Internet Performance','Yes - No issues__'),
+        (@schoolId1,@studentUsi1,'Digital Device','Chromebook__'),
+        (@schoolId1,@studentUsi1,'Device Access','School Provided - Dedicated__'),
 
         -- This record is for a different student
-        (@districtId,@studentUsi2,'DeviceAccess','School Provided - DedicatedX');
+        (@districtId,@studentUsi2,'Device Access','School Provided - DedicatedX');
 
         -- @studentUsi3 is in @districtId but has no indicator records
     </ControlDataInsertion>

--- a/src/EdFi.AnalyticsMiddleTier.Tests/TestCases/StudentLocalEducationAgencyDim/MSSQL/v_4_0/0000_StudentLocalEducationAgencyDim_Data_Load.xml
+++ b/src/EdFi.AnalyticsMiddleTier.Tests/TestCases/StudentLocalEducationAgencyDim/MSSQL/v_4_0/0000_StudentLocalEducationAgencyDim_Data_Load.xml
@@ -167,22 +167,22 @@
         (EducationOrganizationId,StudentUSI,IndicatorName,Indicator)
         VALUES
         -- @studentUsi1 happy path
-        (@districtId,@studentUsi1,'InternetAccessInResidence','Yes'),
-        (@districtId,@studentUsi1,'InternetAccessTypeInResidence','ResidentialBroadband'),
-        (@districtId,@studentUsi1,'InternetPerformance','Yes - No issues'),
-        (@districtId,@studentUsi1,'DigitalDevice','Chromebook'),
-        (@districtId,@studentUsi1,'DeviceAccess','School Provided - Dedicated'),
+        (@districtId,@studentUsi1,'Internet Access In Residence','Yes'),
+        (@districtId,@studentUsi1,'Internet Access Type In Residence','ResidentialBroadband'),
+        (@districtId,@studentUsi1,'Internet Performance','Yes - No issues'),
+        (@districtId,@studentUsi1,'Digital Device','Chromebook'),
+        (@districtId,@studentUsi1,'Device Access','School Provided - Dedicated'),
 
         -- These extra records should be ignored by the view because
         -- they are associated with the School, not the District
-        (@schoolId1,@studentUsi1,'InternetAccessInResidence','Yes__'),
-        (@schoolId1,@studentUsi1,'InternetAccessTypeInResidence','ResidentialBroadband__'),
-        (@schoolId1,@studentUsi1,'InternetPerformance','Yes - No issues__'),
-        (@schoolId1,@studentUsi1,'DigitalDevice','Chromebook__'),
-        (@schoolId1,@studentUsi1,'DeviceAccess','School Provided - Dedicated__'),
+        (@schoolId1,@studentUsi1,'Internet Access In Residence','Yes__'),
+        (@schoolId1,@studentUsi1,'Internet Access Type In Residence','ResidentialBroadband__'),
+        (@schoolId1,@studentUsi1,'Internet Performance','Yes - No issues__'),
+        (@schoolId1,@studentUsi1,'Digital Device','Chromebook__'),
+        (@schoolId1,@studentUsi1,'Device Access','School Provided - Dedicated__'),
 
         -- This record is for a different student
-        (@districtId,@studentUsi2,'DeviceAccess','School Provided - DedicatedX');
+        (@districtId,@studentUsi2,'Device Access','School Provided - DedicatedX');
 
         -- @studentUsi3 is in @districtId but has no indicator records
     </ControlDataInsertion>

--- a/src/EdFi.AnalyticsMiddleTier.Tests/TestCases/StudentLocalEducationAgencyDim/PostgreSQL/v_3_3/0000_StudentLocalEducationAgencyDim_Data_Load.xml
+++ b/src/EdFi.AnalyticsMiddleTier.Tests/TestCases/StudentLocalEducationAgencyDim/PostgreSQL/v_3_3/0000_StudentLocalEducationAgencyDim_Data_Load.xml
@@ -133,21 +133,21 @@
         (EducationOrganizationId,StudentUSI,IndicatorName,Indicator)
         VALUES
         -- '100005230' happy path
-        ('867530','100005230','InternetAccessInResidence','Yes'),
-        ('867530','100005230','InternetAccessTypeInResidence','ResidentialBroadband'),
-        ('867530','100005230','InternetPerformance','Yes - No issues'),
-        ('867530','100005230','DigitalDevice','Chromebook'),
-        ('867530','100005230','DeviceAccess','School Provided - Dedicated'),
+        ('867530','100005230','Internet Access In Residence','Yes'),
+        ('867530','100005230','Internet Access Type In Residence','ResidentialBroadband'),
+        ('867530','100005230','Internet Performance','Yes - No issues'),
+        ('867530','100005230','Digital Device','Chromebook'),
+        ('867530','100005230','Device Access','School Provided - Dedicated'),
 
         -- These extra records should be ignored by the view because
         -- they are associated with the School, not the District
-        ('867530011','100005230','InternetAccessInResidence','Yes__'),
-        ('867530011','100005230','InternetAccessTypeInResidence','ResidentialBroadband__'),
-        ('867530011','100005230','InternetPerformance','Yes - No issues__'),
-        ('867530011','100005230','DigitalDevice','Chromebook__'),
-        ('867530011','100005230','DeviceAccess','School Provided - Dedicated__'),
+        ('867530011','100005230','Internet Access In Residence','Yes__'),
+        ('867530011','100005230','Internet Access Type In Residence','ResidentialBroadband__'),
+        ('867530011','100005230','Internet Performance','Yes - No issues__'),
+        ('867530011','100005230','Digital Device','Chromebook__'),
+        ('867530011','100005230','Device Access','School Provided - Dedicated__'),
 
         -- This record is for a different student
-        ('867530','100020850','DeviceAccess','School Provided - DedicatedX');
+        ('867530','100020850','Device Access','School Provided - DedicatedX');
     </ControlDataInsertion>
 </TestCase>

--- a/src/EdFi.AnalyticsMiddleTier.Tests/TestCases/StudentLocalEducationAgencyDim/PostgreSQL/v_4_0/0000_StudentLocalEducationAgencyDim_Data_Load.xml
+++ b/src/EdFi.AnalyticsMiddleTier.Tests/TestCases/StudentLocalEducationAgencyDim/PostgreSQL/v_4_0/0000_StudentLocalEducationAgencyDim_Data_Load.xml
@@ -133,21 +133,21 @@
         (EducationOrganizationId,StudentUSI,IndicatorName,Indicator)
         VALUES
         -- '100005230' happy path
-        ('867530','100005230','InternetAccessInResidence','Yes'),
-        ('867530','100005230','InternetAccessTypeInResidence','ResidentialBroadband'),
-        ('867530','100005230','InternetPerformance','Yes - No issues'),
-        ('867530','100005230','DigitalDevice','Chromebook'),
-        ('867530','100005230','DeviceAccess','School Provided - Dedicated'),
+        ('867530','100005230','Internet Access In Residence','Yes'),
+        ('867530','100005230','Internet Access Type In Residence','ResidentialBroadband'),
+        ('867530','100005230','Internet Performance','Yes - No issues'),
+        ('867530','100005230','Digital Device','Chromebook'),
+        ('867530','100005230','Device Access','School Provided - Dedicated'),
 
         -- These extra records should be ignored by the view because
         -- they are associated with the School, not the District
-        ('867530011','100005230','InternetAccessInResidence','Yes__'),
-        ('867530011','100005230','InternetAccessTypeInResidence','ResidentialBroadband__'),
-        ('867530011','100005230','InternetPerformance','Yes - No issues__'),
-        ('867530011','100005230','DigitalDevice','Chromebook__'),
-        ('867530011','100005230','DeviceAccess','School Provided - Dedicated__'),
+        ('867530011','100005230','Internet Access In Residence','Yes__'),
+        ('867530011','100005230','Internet Access Type In Residence','ResidentialBroadband__'),
+        ('867530011','100005230','Internet Performance','Yes - No issues__'),
+        ('867530011','100005230','Digital Device','Chromebook__'),
+        ('867530011','100005230','Device Access','School Provided - Dedicated__'),
 
         -- This record is for a different student
-        ('867530','100020850','DeviceAccess','School Provided - DedicatedX');
+        ('867530','100020850','Device Access','School Provided - DedicatedX');
     </ControlDataInsertion>
 </TestCase>


### PR DESCRIPTION
Update indicators to add spaces between word (DS 3.3, 4.0) Replace values:
- InternetAccessInResidence -> Internet Access In Residence
- InternetAccessTypeInResidence -> Internet Access Type In Residence
- InternetPerformance -> Internet Performance
- DigitalDevice -> Digital Device
- DeviceAccess -> Device Access