### PR TITLE
[BIA-1351] Update AMT to .NET 8 and Latest Packages

### DIFF
--- a/src/EdFi.AnalyticsMiddleTier.Common/EdFi.AnalyticsMiddleTier.Common.csproj
+++ b/src/EdFi.AnalyticsMiddleTier.Common/EdFi.AnalyticsMiddleTier.Common.csproj
@@ -1,15 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dapper" Version="2.0.123" />
-    <PackageReference Include="dbup-core" Version="5.0.10" />
-    <PackageReference Include="dbup-postgresql" Version="5.0.8" />
-    <PackageReference Include="dbup-sqlserver" Version="5.0.8" />
-    <PackageReference Include="Npgsql" Version="7.0.1" />
+    <PackageReference Include="Dapper" Version="2.1.21" />
+    <PackageReference Include="dbup-core" Version="5.0.37" />
+    <PackageReference Include="dbup-postgresql" Version="5.0.37" />
+    <PackageReference Include="dbup-sqlserver" Version="5.0.37" />
+    <PackageReference Include="Npgsql" Version="7.0.6" />
   </ItemGroup>
 
 </Project>

--- a/src/EdFi.AnalyticsMiddleTier.Console/EdFi.AnalyticsMiddleTier.Console.csproj
+++ b/src/EdFi.AnalyticsMiddleTier.Console/EdFi.AnalyticsMiddleTier.Console.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <Authors>Ed-Fi Alliance</Authors>
     <Company>Ed-Fi Alliance</Company>
@@ -19,7 +19,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
-    <PackageReference Include="DbUp" Version="5.0.8" />
+    <PackageReference Include="DbUp" Version="5.0.37" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/EdFi.AnalyticsMiddleTier.DataStandard2/EdFi.AnalyticsMiddleTier.DataStandard2.csproj
+++ b/src/EdFi.AnalyticsMiddleTier.DataStandard2/EdFi.AnalyticsMiddleTier.DataStandard2.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Authors>Ed-Fi Alliance</Authors>
     <Copyright>Copyright (c) 2018, Ed-Fi Alliance</Copyright>
     <Version>1.1.0</Version>

--- a/src/EdFi.AnalyticsMiddleTier.DataStandard31/EdFi.AnalyticsMiddleTier.DataStandard31.csproj
+++ b/src/EdFi.AnalyticsMiddleTier.DataStandard31/EdFi.AnalyticsMiddleTier.DataStandard31.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Authors>Ed-Fi Alliance</Authors>
     <Copyright>Copyright (c) 2019, Ed-Fi Alliance LLC and contributors</Copyright>
   </PropertyGroup>

--- a/src/EdFi.AnalyticsMiddleTier.DataStandard32/EdFi.AnalyticsMiddleTier.DataStandard32.csproj
+++ b/src/EdFi.AnalyticsMiddleTier.DataStandard32/EdFi.AnalyticsMiddleTier.DataStandard32.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <Authors>Ed-Fi Alliance</Authors>
         <Copyright>Copyright (c) 2020, Ed-Fi Alliance LLC and contributors</Copyright>
     </PropertyGroup>

--- a/src/EdFi.AnalyticsMiddleTier.DataStandard33/EdFi.AnalyticsMiddleTier.DataStandard33.csproj
+++ b/src/EdFi.AnalyticsMiddleTier.DataStandard33/EdFi.AnalyticsMiddleTier.DataStandard33.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <Authors>Ed-Fi Alliance</Authors>
         <Copyright>Copyright (c) 2020, Ed-Fi Alliance LLC and contributors</Copyright>
     </PropertyGroup>

--- a/src/EdFi.AnalyticsMiddleTier.DataStandard40/EdFi.AnalyticsMiddleTier.DataStandard40.csproj
+++ b/src/EdFi.AnalyticsMiddleTier.DataStandard40/EdFi.AnalyticsMiddleTier.DataStandard40.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <Authors>Ed-Fi Alliance</Authors>
         <Copyright>Copyright (c) 2020, Ed-Fi Alliance LLC and contributors</Copyright>
     </PropertyGroup>

--- a/src/EdFi.AnalyticsMiddleTier.Tests/EdFi.AnalyticsMiddleTier.Tests.csproj
+++ b/src/EdFi.AnalyticsMiddleTier.Tests/EdFi.AnalyticsMiddleTier.Tests.csproj
@@ -4,7 +4,7 @@
   </PropertyGroup>
   
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
@@ -24,17 +24,17 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dapper" Version="2.0.123" />
-    <PackageReference Include="dbup" Version="5.0.8" />
-    <PackageReference Include="dbup-core" Version="5.0.10" />
-    <PackageReference Include="dbup-sqlserver" Version="5.0.8" />
-    <PackageReference Include="dotenv.net" Version="3.1.2" />
-    <PackageReference Include="FakeItEasy" Version="7.3.1" />
-    <PackageReference Include="Microsoft.SqlServer.DacFx" Version="161.6374.0" />
-    <PackageReference Include="nunit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="Shouldly" Version="4.1.0" />
+    <PackageReference Include="Dapper" Version="2.1.21" />
+    <PackageReference Include="dbup" Version="5.0.37" />
+    <PackageReference Include="dbup-core" Version="5.0.37" />
+    <PackageReference Include="dbup-sqlserver" Version="5.0.37" />
+    <PackageReference Include="dotenv.net" Version="3.1.3" />
+    <PackageReference Include="FakeItEasy" Version="8.0.0" />
+    <PackageReference Include="Microsoft.SqlServer.DacFx" Version="162.1.167" />
+    <PackageReference Include="nunit" Version="3.14.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Shouldly" Version="4.2.1" />
     <PackageReference Include="XmlDiffPatch.Core" Version="1.0.1" />
     <PackageReference Include="XmlDiffView.Core" Version="1.0.1" />
   </ItemGroup>


### PR DESCRIPTION
Upgrade projects to use NET 8.0.
Upgrade packages:
- Dapper
- dbup-core
- dbup-postgresql
- dbup-sqlserver
- dotenv.net
- FakeItEasy
- Microsoft.SqlServer.DacFx
- Microsoft.NET.Test.Sdk
- Npgsql
- nunit
- NUnit3TestAdapter
- Shouldly